### PR TITLE
Implement read-only CoreProtect API service

### DIFF
--- a/CoreProtectAPI.sln
+++ b/CoreProtectAPI.sln
@@ -1,0 +1,56 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{41E75273-49F9-42DD-BB1E-EED91693A037}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{72C6E588-2538-4C36-A46F-42538DF1F0CA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreProtect.Api", "src/CoreProtect.Api/CoreProtect.Api.csproj", "{359EB147-E4A3-41BC-8DA5-8B61D0078123}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreProtect.Application", "src/CoreProtect.Application/CoreProtect.Application.csproj", "{5AE70421-BB93-41A8-82FF-DFFF09E0A5A1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreProtect.Domain", "src/CoreProtect.Domain/CoreProtect.Domain.csproj", "{0FE0A386-70F4-45A7-8F60-DB14B93EA4A2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreProtect.Infrastructure", "src/CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj", "{B1E1D0B5-3B37-4E27-9066-2D516003C03D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreProtect.Tests", "tests/CoreProtect.Tests/CoreProtect.Tests.csproj", "{D635E4C6-101A-480B-8AC8-28F9AA127887}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{359EB147-E4A3-41BC-8DA5-8B61D0078123}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{359EB147-E4A3-41BC-8DA5-8B61D0078123}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{359EB147-E4A3-41BC-8DA5-8B61D0078123}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{359EB147-E4A3-41BC-8DA5-8B61D0078123}.Release|Any CPU.Build.0 = Release|Any CPU
+{5AE70421-BB93-41A8-82FF-DFFF09E0A5A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{5AE70421-BB93-41A8-82FF-DFFF09E0A5A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{5AE70421-BB93-41A8-82FF-DFFF09E0A5A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{5AE70421-BB93-41A8-82FF-DFFF09E0A5A1}.Release|Any CPU.Build.0 = Release|Any CPU
+{0FE0A386-70F4-45A7-8F60-DB14B93EA4A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{0FE0A386-70F4-45A7-8F60-DB14B93EA4A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{0FE0A386-70F4-45A7-8F60-DB14B93EA4A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{0FE0A386-70F4-45A7-8F60-DB14B93EA4A2}.Release|Any CPU.Build.0 = Release|Any CPU
+{B1E1D0B5-3B37-4E27-9066-2D516003C03D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{B1E1D0B5-3B37-4E27-9066-2D516003C03D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{B1E1D0B5-3B37-4E27-9066-2D516003C03D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{B1E1D0B5-3B37-4E27-9066-2D516003C03D}.Release|Any CPU.Build.0 = Release|Any CPU
+{D635E4C6-101A-480B-8AC8-28F9AA127887}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{D635E4C6-101A-480B-8AC8-28F9AA127887}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{D635E4C6-101A-480B-8AC8-28F9AA127887}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{D635E4C6-101A-480B-8AC8-28F9AA127887}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+GlobalSection(NestedProjects) = preSolution
+{359EB147-E4A3-41BC-8DA5-8B61D0078123} = {41E75273-49F9-42DD-BB1E-EED91693A037}
+{5AE70421-BB93-41A8-82FF-DFFF09E0A5A1} = {41E75273-49F9-42DD-BB1E-EED91693A037}
+{0FE0A386-70F4-45A7-8F60-DB14B93EA4A2} = {41E75273-49F9-42DD-BB1E-EED91693A037}
+{B1E1D0B5-3B37-4E27-9066-2D516003C03D} = {41E75273-49F9-42DD-BB1E-EED91693A037}
+{D635E4C6-101A-480B-8AC8-28F9AA127887} = {72C6E588-2538-4C36-A46F-42538DF1F0CA}
+EndGlobalSection
+EndGlobal

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish src/CoreProtect.Api/CoreProtect.Api.csproj -c Release -o /app
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
+WORKDIR /app
+COPY --from=build /app .
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+ENTRYPOINT ["dotnet","CoreProtect.Api.dll"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,129 @@
-# CoreProtectAPI
+# CoreProtect API
+
+Read-only REST API that exposes CoreProtect audit data via HTTP. The service targets CoreProtect MySQL/MariaDB backends and surfaces blocks, container interactions, item transactions, commands, chat, sessions, and signs with decoded metadata.
+
+## Features
+
+* REST endpoints under `/v1` with consistent filtering for world, users (including historical usernames), time ranges, coordinates, and pagination.
+* Safe SQL templates that respect CoreProtect indexing strategy and never touch `rowid`.
+* Binary metadata decoding (Java Serialization subset + NBT) with graceful fallback to raw hex/base64.
+* API key protection via `X-Api-Key`, structured error responses, and basic health probes (`/healthz`, `/readyz`).
+* Slow SQL logging (>500 ms), HTTP request logging, and configurable limits via environment variables.
+* Docker-ready `.NET 8` service with clean layering (Domain → Application → Infrastructure → API).
+
+## Project structure
+
+```
+CoreProtectAPI
+├── CoreProtectAPI.sln
+├── README.md
+├── src/
+│   ├── CoreProtect.Domain/       # Entities and value objects
+│   ├── CoreProtect.Application/  # Query services and abstractions
+│   ├── CoreProtect.Infrastructure/ # MySQL access, metadata decoding, DI
+│   └── CoreProtect.Api/          # ASP.NET Core host and controllers
+└── tests/
+    └── CoreProtect.Tests/        # xUnit test suite
+```
+
+## Getting started
+
+### Requirements
+
+* .NET SDK 8.0
+* MySQL or MariaDB with CoreProtect schema accessible via read-only user (`cp_reader`).
+
+### Configuration
+
+Configuration is provided through `appsettings.json` and overridable environment variables.
+
+| Setting | Environment key | Default | Description |
+| ------- | ---------------- | ------- | ----------- |
+| Connection string | `ConnectionStrings__CoreProtect` | `Server=localhost;Port=3306;Database=coreprotect;Uid=cp_reader;Pwd=change-me;SslMode=None` | CoreProtect database connection. |
+| Default limit | `API__DefaultLimit` | `10` | Default page size when `limit` is omitted. |
+| Max limit | `API__MaxLimit` | `500` | Maximum allowed `limit`. |
+| API key toggle | `API__EnableApiKey` | `false` | Enables header based authentication. |
+| API key value | `API__ApiKey` | _empty_ | Value compared against `X-Api-Key`. |
+| CORS origins | `API__Cors__Origins` | `[]` | Comma-separated list of allowed origins. |
+
+### Running locally
+
+```bash
+# Restore dependencies
+dotnet restore
+
+# Run the web API
+dotnet run --project src/CoreProtect.Api/CoreProtect.Api.csproj
+```
+
+### Docker
+
+```
+docker build -t coreprotect-api .
+docker run -p 8080:8080 \
+  -e ConnectionStrings__CoreProtect="Server=db;Port=3306;Database=coreprotect;Uid=cp_reader;Pwd=secret;SslMode=None" \
+  -e API__EnableApiKey=true \
+  -e API__ApiKey=change-me \
+  coreprotect-api
+```
+
+### Testing
+
+```bash
+dotnet test
+```
+
+> **Note:** Ensure the .NET 8 SDK is installed before running the commands above.
+
+## API overview
+
+* `GET /v1/worlds` – list available worlds.
+* `GET /v1/users/search?name=...` – partial username search (max 50 results).
+* `GET /v1/users/resolve?name=...` – resolve historical usernames.
+* `GET /v1/blocks` – block place/break history.
+* `GET /v1/containers` – container interactions with metadata decoding.
+* `GET /v1/items` – item pickup/drop events.
+* `GET /v1/commands` – command executions (`message` returned as `command`).
+* `GET /v1/chat` – chat messages.
+* `GET /v1/sessions` – login/logout events.
+* `GET /v1/signs` – sign placements/updates with lines and colors.
+
+All endpoints accept shared query parameters:
+
+| Parameter | Description |
+| --------- | ----------- |
+| `limit` | Page size (1–500, default configured via `API__DefaultLimit`). |
+| `offset` | Offset for pagination (default 0). |
+| `sort` | `asc` or `desc` (default `desc`). |
+| `from` / `to` | Unix seconds (inclusive/exclusive). |
+| `world` | Exact world name. |
+| `user` | Exact username (matches current or historical). |
+| `userLike` | Case-insensitive substring match. |
+| `xMin`–`xMax`, `yMin`–`yMax`, `zMin`–`zMax` | Coordinate bounds. |
+
+Endpoint specific filters are available (e.g. `action`, `blockTypeId`, `command`, `message`). Responses include both Unix time (`time`) and ISO-8601 (`timestamp`) values.
+
+## Security and operations
+
+* Create a dedicated database user (`cp_reader`) with `SELECT` privileges only.
+* Enable the API key header check for public deployments.
+* Monitor slow query logs – anything over 500 ms is logged at `Warning` level.
+* Health probes: `/healthz` for liveness, `/readyz` for readiness.
+
+## Metadata decoding
+
+The metadata decoder attempts, in order:
+
+1. Java serialization (supporting `HashMap`, `LinkedHashMap`, `ArrayList`, enums, Guava immutable map payloads).
+2. NBT (uncompressed, Java edition layout).
+3. Fallback to truncated hex/base64.
+
+Decoded JSON is emitted inline (`metaJson`), with raw payloads provided separately when decoding fails.
+
+## Indexing and performance
+
+The SQL queries assume the CoreProtect indices listed in the technical specification. Ensure they exist to maintain the SLO target (≤300 ms p95 for typical queries). Timeout defaults: 5 s for SQL commands, 10 s for HTTP requests.
+
+## License
+
+MIT

--- a/src/CoreProtect.Api/Configuration/ApiSettings.cs
+++ b/src/CoreProtect.Api/Configuration/ApiSettings.cs
@@ -1,0 +1,17 @@
+namespace CoreProtect.Api.Configuration;
+
+public sealed class ApiSettings
+{
+    public const string SectionName = "API";
+
+    public int DefaultLimit { get; init; } = 10;
+    public int MaxLimit { get; init; } = 500;
+    public bool EnableApiKey { get; init; }
+    public string? ApiKey { get; init; }
+    public CorsSettings Cors { get; init; } = new();
+
+    public sealed class CorsSettings
+    {
+        public string[] Origins { get; init; } = Array.Empty<string>();
+    }
+}

--- a/src/CoreProtect.Api/Controllers/BlocksController.cs
+++ b/src/CoreProtect.Api/Controllers/BlocksController.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Linq;
+using CoreProtect.Api.Configuration;
+using CoreProtect.Api.Models;
+using CoreProtect.Application.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace CoreProtect.Api.Controllers;
+
+[ApiController]
+[Route("v1/blocks")]
+public sealed class BlocksController : ControllerBase
+{
+    private readonly ICoreProtectQueryService _service;
+    private readonly IOptions<ApiSettings> _settings;
+
+    public BlocksController(ICoreProtectQueryService service, IOptions<ApiSettings> settings)
+    {
+        _service = service;
+        _settings = settings;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<BlockDto>>> GetAsync([FromQuery] BlockQueryRequest request, CancellationToken cancellationToken)
+    {
+        var parameters = request.Build(_settings.Value);
+        var entries = await _service.GetBlocksAsync(parameters, cancellationToken).ConfigureAwait(false);
+        return Ok(entries.Select(BlockDto.FromDomain));
+    }
+}

--- a/src/CoreProtect.Api/Controllers/ChatController.cs
+++ b/src/CoreProtect.Api/Controllers/ChatController.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Linq;
+using CoreProtect.Api.Configuration;
+using CoreProtect.Api.Models;
+using CoreProtect.Application.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace CoreProtect.Api.Controllers;
+
+[ApiController]
+[Route("v1/chat")]
+public sealed class ChatController : ControllerBase
+{
+    private readonly ICoreProtectQueryService _service;
+    private readonly IOptions<ApiSettings> _settings;
+
+    public ChatController(ICoreProtectQueryService service, IOptions<ApiSettings> settings)
+    {
+        _service = service;
+        _settings = settings;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<ChatDto>>> GetAsync([FromQuery] ChatQueryRequest request, CancellationToken cancellationToken)
+    {
+        var parameters = request.Build(_settings.Value);
+        var entries = await _service.GetChatAsync(parameters, cancellationToken).ConfigureAwait(false);
+        return Ok(entries.Select(ChatDto.FromDomain));
+    }
+}

--- a/src/CoreProtect.Api/Controllers/CommandsController.cs
+++ b/src/CoreProtect.Api/Controllers/CommandsController.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Linq;
+using CoreProtect.Api.Configuration;
+using CoreProtect.Api.Models;
+using CoreProtect.Application.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace CoreProtect.Api.Controllers;
+
+[ApiController]
+[Route("v1/commands")]
+public sealed class CommandsController : ControllerBase
+{
+    private readonly ICoreProtectQueryService _service;
+    private readonly IOptions<ApiSettings> _settings;
+
+    public CommandsController(ICoreProtectQueryService service, IOptions<ApiSettings> settings)
+    {
+        _service = service;
+        _settings = settings;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<CommandDto>>> GetAsync([FromQuery] CommandQueryRequest request, CancellationToken cancellationToken)
+    {
+        var parameters = request.Build(_settings.Value);
+        var entries = await _service.GetCommandsAsync(parameters, cancellationToken).ConfigureAwait(false);
+        return Ok(entries.Select(CommandDto.FromDomain));
+    }
+}

--- a/src/CoreProtect.Api/Controllers/ContainersController.cs
+++ b/src/CoreProtect.Api/Controllers/ContainersController.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Linq;
+using CoreProtect.Api.Configuration;
+using CoreProtect.Api.Models;
+using CoreProtect.Application.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace CoreProtect.Api.Controllers;
+
+[ApiController]
+[Route("v1/containers")]
+public sealed class ContainersController : ControllerBase
+{
+    private readonly ICoreProtectQueryService _service;
+    private readonly IOptions<ApiSettings> _settings;
+
+    public ContainersController(ICoreProtectQueryService service, IOptions<ApiSettings> settings)
+    {
+        _service = service;
+        _settings = settings;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<ContainerDto>>> GetAsync([FromQuery] ContainerQueryRequest request, CancellationToken cancellationToken)
+    {
+        var parameters = request.Build(_settings.Value);
+        var entries = await _service.GetContainersAsync(parameters, cancellationToken).ConfigureAwait(false);
+        return Ok(entries.Select(ContainerDto.FromDomain));
+    }
+}

--- a/src/CoreProtect.Api/Controllers/ItemsController.cs
+++ b/src/CoreProtect.Api/Controllers/ItemsController.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Linq;
+using CoreProtect.Api.Configuration;
+using CoreProtect.Api.Models;
+using CoreProtect.Application.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace CoreProtect.Api.Controllers;
+
+[ApiController]
+[Route("v1/items")]
+public sealed class ItemsController : ControllerBase
+{
+    private readonly ICoreProtectQueryService _service;
+    private readonly IOptions<ApiSettings> _settings;
+
+    public ItemsController(ICoreProtectQueryService service, IOptions<ApiSettings> settings)
+    {
+        _service = service;
+        _settings = settings;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<ItemDto>>> GetAsync([FromQuery] ItemQueryRequest request, CancellationToken cancellationToken)
+    {
+        var parameters = request.Build(_settings.Value);
+        var entries = await _service.GetItemsAsync(parameters, cancellationToken).ConfigureAwait(false);
+        return Ok(entries.Select(ItemDto.FromDomain));
+    }
+}

--- a/src/CoreProtect.Api/Controllers/SessionsController.cs
+++ b/src/CoreProtect.Api/Controllers/SessionsController.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Linq;
+using CoreProtect.Api.Configuration;
+using CoreProtect.Api.Models;
+using CoreProtect.Application.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace CoreProtect.Api.Controllers;
+
+[ApiController]
+[Route("v1/sessions")]
+public sealed class SessionsController : ControllerBase
+{
+    private readonly ICoreProtectQueryService _service;
+    private readonly IOptions<ApiSettings> _settings;
+
+    public SessionsController(ICoreProtectQueryService service, IOptions<ApiSettings> settings)
+    {
+        _service = service;
+        _settings = settings;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<SessionDto>>> GetAsync([FromQuery] SessionQueryRequest request, CancellationToken cancellationToken)
+    {
+        var parameters = request.Build(_settings.Value);
+        var entries = await _service.GetSessionsAsync(parameters, cancellationToken).ConfigureAwait(false);
+        return Ok(entries.Select(SessionDto.FromDomain));
+    }
+}

--- a/src/CoreProtect.Api/Controllers/SignsController.cs
+++ b/src/CoreProtect.Api/Controllers/SignsController.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Linq;
+using CoreProtect.Api.Configuration;
+using CoreProtect.Api.Models;
+using CoreProtect.Application.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace CoreProtect.Api.Controllers;
+
+[ApiController]
+[Route("v1/signs")]
+public sealed class SignsController : ControllerBase
+{
+    private readonly ICoreProtectQueryService _service;
+    private readonly IOptions<ApiSettings> _settings;
+
+    public SignsController(ICoreProtectQueryService service, IOptions<ApiSettings> settings)
+    {
+        _service = service;
+        _settings = settings;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<SignDto>>> GetAsync([FromQuery] SignQueryRequest request, CancellationToken cancellationToken)
+    {
+        var parameters = request.Build(_settings.Value);
+        var entries = await _service.GetSignsAsync(parameters, cancellationToken).ConfigureAwait(false);
+        return Ok(entries.Select(SignDto.FromDomain));
+    }
+}

--- a/src/CoreProtect.Api/Controllers/UsersController.cs
+++ b/src/CoreProtect.Api/Controllers/UsersController.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Linq;
+using CoreProtect.Api.Exceptions;
+using CoreProtect.Api.Models;
+using CoreProtect.Application.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CoreProtect.Api.Controllers;
+
+[ApiController]
+[Route("v1/users")]
+public sealed class UsersController : ControllerBase
+{
+    private readonly ICoreProtectQueryService _service;
+
+    public UsersController(ICoreProtectQueryService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet("search")]
+    public async Task<ActionResult<IEnumerable<UserSearchDto>>> SearchAsync([FromQuery(Name = "name")] string name, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ValidationException("Query parameter 'name' is required.");
+        }
+
+        var results = await _service.SearchUsersAsync(name.Trim(), cancellationToken).ConfigureAwait(false);
+        return Ok(results.Select(UserSearchDto.FromDomain));
+    }
+
+    [HttpGet("resolve")]
+    public async Task<ActionResult<IEnumerable<UserResolutionDto>>> ResolveAsync([FromQuery(Name = "name")] string name, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ValidationException("Query parameter 'name' is required.");
+        }
+
+        var results = await _service.ResolveUserAsync(name.Trim(), cancellationToken).ConfigureAwait(false);
+        return Ok(results.Select(UserResolutionDto.FromDomain));
+    }
+}

--- a/src/CoreProtect.Api/Controllers/WorldsController.cs
+++ b/src/CoreProtect.Api/Controllers/WorldsController.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Linq;
+using CoreProtect.Api.Models;
+using CoreProtect.Application.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CoreProtect.Api.Controllers;
+
+[ApiController]
+[Route("v1/worlds")]
+public sealed class WorldsController : ControllerBase
+{
+    private readonly ICoreProtectQueryService _service;
+
+    public WorldsController(ICoreProtectQueryService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<WorldDto>>> GetAsync(CancellationToken cancellationToken)
+    {
+        var worlds = await _service.GetWorldsAsync(cancellationToken).ConfigureAwait(false);
+        return Ok(worlds.Select(WorldDto.FromDomain));
+    }
+}

--- a/src/CoreProtect.Api/CoreProtect.Api.csproj
+++ b/src/CoreProtect.Api/CoreProtect.Api.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../CoreProtect.Application/CoreProtect.Application.csproj" />
+    <ProjectReference Include="../CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj" />
+    <ProjectReference Include="../CoreProtect.Domain/CoreProtect.Domain.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
+  </ItemGroup>
+</Project>

--- a/src/CoreProtect.Api/Exceptions/ApiException.cs
+++ b/src/CoreProtect.Api/Exceptions/ApiException.cs
@@ -1,0 +1,14 @@
+using System.Net;
+
+namespace CoreProtect.Api.Exceptions;
+
+public abstract class ApiException : Exception
+{
+    protected ApiException(string message, HttpStatusCode statusCode)
+        : base(message)
+    {
+        StatusCode = statusCode;
+    }
+
+    public HttpStatusCode StatusCode { get; }
+}

--- a/src/CoreProtect.Api/Exceptions/UnauthorizedException.cs
+++ b/src/CoreProtect.Api/Exceptions/UnauthorizedException.cs
@@ -1,0 +1,10 @@
+using System.Net;
+
+namespace CoreProtect.Api.Exceptions;
+
+public sealed class UnauthorizedException : ApiException
+{
+    public UnauthorizedException(string message) : base(message, HttpStatusCode.Unauthorized)
+    {
+    }
+}

--- a/src/CoreProtect.Api/Exceptions/ValidationException.cs
+++ b/src/CoreProtect.Api/Exceptions/ValidationException.cs
@@ -1,0 +1,10 @@
+using System.Net;
+
+namespace CoreProtect.Api.Exceptions;
+
+public sealed class ValidationException : ApiException
+{
+    public ValidationException(string message) : base(message, HttpStatusCode.BadRequest)
+    {
+    }
+}

--- a/src/CoreProtect.Api/Middleware/ApiKeyMiddleware.cs
+++ b/src/CoreProtect.Api/Middleware/ApiKeyMiddleware.cs
@@ -1,0 +1,39 @@
+using CoreProtect.Api.Configuration;
+using CoreProtect.Api.Exceptions;
+using Microsoft.Extensions.Options;
+
+namespace CoreProtect.Api.Middleware;
+
+public sealed class ApiKeyMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly IOptionsMonitor<ApiSettings> _settings;
+
+    public ApiKeyMiddleware(RequestDelegate next, IOptionsMonitor<ApiSettings> settings)
+    {
+        _next = next;
+        _settings = settings;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var options = _settings.CurrentValue;
+        if (!options.EnableApiKey)
+        {
+            await _next(context).ConfigureAwait(false);
+            return;
+        }
+
+        if (string.IsNullOrEmpty(options.ApiKey))
+        {
+            throw new UnauthorizedException("API key validation is enabled but no key is configured.");
+        }
+
+        if (!context.Request.Headers.TryGetValue("X-Api-Key", out var provided) || !string.Equals(provided, options.ApiKey, StringComparison.Ordinal))
+        {
+            throw new UnauthorizedException("Invalid API key.");
+        }
+
+        await _next(context).ConfigureAwait(false);
+    }
+}

--- a/src/CoreProtect.Api/Middleware/ErrorHandlingMiddleware.cs
+++ b/src/CoreProtect.Api/Middleware/ErrorHandlingMiddleware.cs
@@ -1,0 +1,50 @@
+using System.Diagnostics;
+using System.Net;
+using System.Text.Json;
+using CoreProtect.Api.Exceptions;
+
+namespace CoreProtect.Api.Middleware;
+
+public sealed class ErrorHandlingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<ErrorHandlingMiddleware> _logger;
+
+    public ErrorHandlingMiddleware(RequestDelegate next, ILogger<ErrorHandlingMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await _next(context).ConfigureAwait(false);
+        }
+        catch (ApiException ex)
+        {
+            await WriteProblemAsync(context, ex.StatusCode, ex.Message).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception while processing {Path}", context.Request.Path);
+            await WriteProblemAsync(context, HttpStatusCode.InternalServerError, "An unexpected error occurred.").ConfigureAwait(false);
+        }
+    }
+
+    private static async Task WriteProblemAsync(HttpContext context, HttpStatusCode statusCode, string message)
+    {
+        context.Response.ContentType = "application/json";
+        context.Response.StatusCode = (int)statusCode;
+        var traceId = Activity.Current?.Id ?? context.TraceIdentifier;
+        var payload = new
+        {
+            error = statusCode == HttpStatusCode.BadRequest ? "BadRequest" : statusCode.ToString(),
+            message,
+            traceId
+        };
+
+        await context.Response.WriteAsync(JsonSerializer.Serialize(payload)).ConfigureAwait(false);
+    }
+}

--- a/src/CoreProtect.Api/Models/BlockDto.cs
+++ b/src/CoreProtect.Api/Models/BlockDto.cs
@@ -1,0 +1,31 @@
+using CoreProtect.Domain.Entities;
+using CoreProtect.Domain.ValueObjects;
+
+namespace CoreProtect.Api.Models;
+
+public sealed record BlockDto(
+    long Time,
+    string Timestamp,
+    string User,
+    string World,
+    int X,
+    int Y,
+    int Z,
+    string Action,
+    int BlockTypeId,
+    string? BlockTypeName,
+    bool RolledBack)
+{
+    public static BlockDto FromDomain(BlockLogEntry entry) => new(
+        entry.Time,
+        entry.Timestamp.ToUniversalTime().ToString("O"),
+        entry.User,
+        entry.World,
+        entry.Coordinates.X,
+        entry.Coordinates.Y,
+        entry.Coordinates.Z,
+        entry.Action == BlockAction.Placed ? "placed" : "broken",
+        entry.BlockTypeId,
+        entry.BlockTypeName,
+        entry.RolledBack);
+}

--- a/src/CoreProtect.Api/Models/BlockQueryRequest.cs
+++ b/src/CoreProtect.Api/Models/BlockQueryRequest.cs
@@ -1,0 +1,30 @@
+using System;
+using CoreProtect.Api.Configuration;
+using CoreProtect.Api.Exceptions;
+using CoreProtect.Application.Common;
+using CoreProtect.Domain.Entities;
+
+namespace CoreProtect.Api.Models;
+
+public sealed class BlockQueryRequest : LogQueryRequest
+{
+    public int? BlockTypeId { get; init; }
+    public string? Action { get; init; }
+
+    public BlockQueryParameters Build(ApiSettings settings)
+    {
+        var baseParams = base.Build(settings);
+        BlockAction? action = null;
+        if (!string.IsNullOrWhiteSpace(Action))
+        {
+            action = Action.ToLowerInvariant() switch
+            {
+                "placed" => BlockAction.Placed,
+                "broken" => BlockAction.Broken,
+                _ => throw new ValidationException("Block action must be either 'placed' or 'broken'.")
+            };
+        }
+
+        return new BlockQueryParameters(baseParams, BlockTypeId, action);
+    }
+}

--- a/src/CoreProtect.Api/Models/ChatDto.cs
+++ b/src/CoreProtect.Api/Models/ChatDto.cs
@@ -1,0 +1,24 @@
+using CoreProtect.Domain.Entities;
+
+namespace CoreProtect.Api.Models;
+
+public sealed record ChatDto(
+    long Time,
+    string Timestamp,
+    string User,
+    string World,
+    int X,
+    int Y,
+    int Z,
+    string Message)
+{
+    public static ChatDto FromDomain(ChatLogEntry entry) => new(
+        entry.Time,
+        entry.Timestamp.ToUniversalTime().ToString("O"),
+        entry.User,
+        entry.World,
+        entry.Coordinates.X,
+        entry.Coordinates.Y,
+        entry.Coordinates.Z,
+        entry.Message);
+}

--- a/src/CoreProtect.Api/Models/ChatQueryRequest.cs
+++ b/src/CoreProtect.Api/Models/ChatQueryRequest.cs
@@ -1,0 +1,17 @@
+using System;
+using CoreProtect.Api.Configuration;
+using CoreProtect.Application.Common;
+
+namespace CoreProtect.Api.Models;
+
+public sealed class ChatQueryRequest : LogQueryRequest
+{
+    public string? Message { get; init; }
+
+    public ChatQueryParameters Build(ApiSettings settings)
+    {
+        var baseParams = base.Build(settings);
+        var messageLike = string.IsNullOrWhiteSpace(Message) ? null : $"%{Message.Trim()}%";
+        return new ChatQueryParameters(baseParams, messageLike);
+    }
+}

--- a/src/CoreProtect.Api/Models/CommandDto.cs
+++ b/src/CoreProtect.Api/Models/CommandDto.cs
@@ -1,0 +1,24 @@
+using CoreProtect.Domain.Entities;
+
+namespace CoreProtect.Api.Models;
+
+public sealed record CommandDto(
+    long Time,
+    string Timestamp,
+    string User,
+    string World,
+    int X,
+    int Y,
+    int Z,
+    string Command)
+{
+    public static CommandDto FromDomain(CommandLogEntry entry) => new(
+        entry.Time,
+        entry.Timestamp.ToUniversalTime().ToString("O"),
+        entry.User,
+        entry.World,
+        entry.Coordinates.X,
+        entry.Coordinates.Y,
+        entry.Coordinates.Z,
+        entry.Command);
+}

--- a/src/CoreProtect.Api/Models/CommandQueryRequest.cs
+++ b/src/CoreProtect.Api/Models/CommandQueryRequest.cs
@@ -1,0 +1,17 @@
+using System;
+using CoreProtect.Api.Configuration;
+using CoreProtect.Application.Common;
+
+namespace CoreProtect.Api.Models;
+
+public sealed class CommandQueryRequest : LogQueryRequest
+{
+    public string? Command { get; init; }
+
+    public CommandQueryParameters Build(ApiSettings settings)
+    {
+        var baseParams = base.Build(settings);
+        var commandLike = string.IsNullOrWhiteSpace(Command) ? null : $"%{Command.Trim()}%";
+        return new CommandQueryParameters(baseParams, commandLike);
+    }
+}

--- a/src/CoreProtect.Api/Models/ContainerDto.cs
+++ b/src/CoreProtect.Api/Models/ContainerDto.cs
@@ -1,0 +1,39 @@
+using CoreProtect.Domain.Entities;
+using CoreProtect.Domain.ValueObjects;
+
+namespace CoreProtect.Api.Models;
+
+public sealed record ContainerDto(
+    long Time,
+    string Timestamp,
+    string User,
+    string World,
+    int X,
+    int Y,
+    int Z,
+    string Action,
+    int ItemTypeId,
+    int ItemData,
+    int Amount,
+    object? MetaJson,
+    string? MetaRawHex,
+    string? MetaBase64,
+    bool RolledBack)
+{
+    public static ContainerDto FromDomain(ContainerLogEntry entry) => new(
+        entry.Time,
+        entry.Timestamp.ToUniversalTime().ToString("O"),
+        entry.User,
+        entry.World,
+        entry.Coordinates.X,
+        entry.Coordinates.Y,
+        entry.Coordinates.Z,
+        entry.Action == ContainerAction.Put ? "put" : "took",
+        entry.ItemTypeId,
+        entry.ItemData,
+        entry.Amount,
+        entry.Metadata.Json,
+        entry.Metadata.RawHex,
+        entry.Metadata.Base64,
+        entry.RolledBack);
+}

--- a/src/CoreProtect.Api/Models/ContainerQueryRequest.cs
+++ b/src/CoreProtect.Api/Models/ContainerQueryRequest.cs
@@ -1,0 +1,14 @@
+using System;
+using CoreProtect.Api.Configuration;
+using CoreProtect.Application.Common;
+
+namespace CoreProtect.Api.Models;
+
+public sealed class ContainerQueryRequest : LogQueryRequest
+{
+    public ContainerQueryParameters Build(ApiSettings settings)
+    {
+        var baseParams = base.Build(settings);
+        return new ContainerQueryParameters(baseParams);
+    }
+}

--- a/src/CoreProtect.Api/Models/ItemDto.cs
+++ b/src/CoreProtect.Api/Models/ItemDto.cs
@@ -1,0 +1,42 @@
+using CoreProtect.Domain.Entities;
+
+namespace CoreProtect.Api.Models;
+
+public sealed record ItemDto(
+    long Time,
+    string Timestamp,
+    string User,
+    string World,
+    int X,
+    int Y,
+    int Z,
+    string Action,
+    int ItemTypeId,
+    int ItemData,
+    int Amount,
+    bool RolledBack)
+{
+    public static ItemDto FromDomain(ItemLogEntry entry)
+    {
+        var action = entry.Action switch
+        {
+            ItemAction.Drop => "drop",
+            ItemAction.Pickup => "pickup",
+            _ => entry.Action.ToString().ToLowerInvariant()
+        };
+
+        return new ItemDto(
+            entry.Time,
+            entry.Timestamp.ToUniversalTime().ToString("O"),
+            entry.User,
+            entry.World,
+            entry.Coordinates.X,
+            entry.Coordinates.Y,
+            entry.Coordinates.Z,
+            action,
+            entry.ItemTypeId,
+            entry.ItemData,
+            entry.Amount,
+            entry.RolledBack);
+    }
+}

--- a/src/CoreProtect.Api/Models/ItemQueryRequest.cs
+++ b/src/CoreProtect.Api/Models/ItemQueryRequest.cs
@@ -1,0 +1,14 @@
+using System;
+using CoreProtect.Api.Configuration;
+using CoreProtect.Application.Common;
+
+namespace CoreProtect.Api.Models;
+
+public sealed class ItemQueryRequest : LogQueryRequest
+{
+    public ItemQueryParameters Build(ApiSettings settings)
+    {
+        var baseParams = base.Build(settings);
+        return new ItemQueryParameters(baseParams);
+    }
+}

--- a/src/CoreProtect.Api/Models/LogQueryRequest.cs
+++ b/src/CoreProtect.Api/Models/LogQueryRequest.cs
@@ -1,0 +1,72 @@
+using System;
+using CoreProtect.Api.Configuration;
+using CoreProtect.Api.Exceptions;
+using CoreProtect.Application.Common;
+using CoreProtect.Domain.Entities;
+
+namespace CoreProtect.Api.Models;
+
+public class LogQueryRequest
+{
+    public string? User { get; init; }
+    public string? UserLike { get; init; }
+    public string? World { get; init; }
+    public long? From { get; init; }
+    public long? To { get; init; }
+    public int? XMin { get; init; }
+    public int? XMax { get; init; }
+    public int? YMin { get; init; }
+    public int? YMax { get; init; }
+    public int? ZMin { get; init; }
+    public int? ZMax { get; init; }
+    public string? Sort { get; init; }
+    public int? Limit { get; init; }
+    public int? Offset { get; init; }
+
+    protected virtual void ValidateSpecific()
+    {
+    }
+
+    public virtual LogQueryParameters Build(ApiSettings settings)
+    {
+        ValidateSpecific();
+        var limit = Limit ?? settings.DefaultLimit;
+        if (limit < 1 || limit > settings.MaxLimit)
+        {
+            throw new ValidationException($"Limit must be between 1 and {settings.MaxLimit}.");
+        }
+
+        var offset = Offset ?? 0;
+        if (offset < 0)
+        {
+            throw new ValidationException("Offset must be non-negative.");
+        }
+
+        var sort = string.Equals(Sort, "asc", StringComparison.OrdinalIgnoreCase) ? SortDirection.Ascending : SortDirection.Descending;
+
+        var coordinateFilter = new CoordinateFilter(XMin, XMax, YMin, YMax, ZMin, ZMax);
+        return new LogQueryParameters(
+            NormalizeUser(User),
+            NormalizeUserLike(UserLike),
+            NormalizeWorld(World),
+            From,
+            To,
+            coordinateFilter,
+            sort,
+            new Pagination(limit, offset));
+    }
+
+    private static string? NormalizeUser(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? NormalizeUserLike(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return $"%{value.Trim()}%";
+    }
+
+    private static string? NormalizeWorld(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/CoreProtect.Api/Models/SessionDto.cs
+++ b/src/CoreProtect.Api/Models/SessionDto.cs
@@ -1,0 +1,24 @@
+using CoreProtect.Domain.Entities;
+
+namespace CoreProtect.Api.Models;
+
+public sealed record SessionDto(
+    long Time,
+    string Timestamp,
+    string User,
+    string World,
+    int X,
+    int Y,
+    int Z,
+    string Action)
+{
+    public static SessionDto FromDomain(SessionLogEntry entry) => new(
+        entry.Time,
+        entry.Timestamp.ToUniversalTime().ToString("O"),
+        entry.User,
+        entry.World,
+        entry.Coordinates.X,
+        entry.Coordinates.Y,
+        entry.Coordinates.Z,
+        entry.Action == SessionAction.Login ? "login" : "logout");
+}

--- a/src/CoreProtect.Api/Models/SessionQueryRequest.cs
+++ b/src/CoreProtect.Api/Models/SessionQueryRequest.cs
@@ -1,0 +1,14 @@
+using System;
+using CoreProtect.Api.Configuration;
+using CoreProtect.Application.Common;
+
+namespace CoreProtect.Api.Models;
+
+public sealed class SessionQueryRequest : LogQueryRequest
+{
+    public SessionQueryParameters Build(ApiSettings settings)
+    {
+        var baseParams = base.Build(settings);
+        return new SessionQueryParameters(baseParams);
+    }
+}

--- a/src/CoreProtect.Api/Models/SignDto.cs
+++ b/src/CoreProtect.Api/Models/SignDto.cs
@@ -1,0 +1,30 @@
+using CoreProtect.Domain.Entities;
+
+namespace CoreProtect.Api.Models;
+
+public sealed record SignDto(
+    long Time,
+    string Timestamp,
+    string User,
+    string World,
+    int X,
+    int Y,
+    int Z,
+    string Action,
+    string? Color,
+    string? GlowingText,
+    IReadOnlyList<string> Lines)
+{
+    public static SignDto FromDomain(SignLogEntry entry) => new(
+        entry.Time,
+        entry.Timestamp.ToUniversalTime().ToString("O"),
+        entry.User,
+        entry.World,
+        entry.Coordinates.X,
+        entry.Coordinates.Y,
+        entry.Coordinates.Z,
+        entry.Action,
+        entry.Color,
+        entry.GlowingText,
+        entry.Lines);
+}

--- a/src/CoreProtect.Api/Models/SignQueryRequest.cs
+++ b/src/CoreProtect.Api/Models/SignQueryRequest.cs
@@ -1,0 +1,14 @@
+using System;
+using CoreProtect.Api.Configuration;
+using CoreProtect.Application.Common;
+
+namespace CoreProtect.Api.Models;
+
+public sealed class SignQueryRequest : LogQueryRequest
+{
+    public SignQueryParameters Build(ApiSettings settings)
+    {
+        var baseParams = base.Build(settings);
+        return new SignQueryParameters(baseParams);
+    }
+}

--- a/src/CoreProtect.Api/Models/UserResolutionDto.cs
+++ b/src/CoreProtect.Api/Models/UserResolutionDto.cs
@@ -1,0 +1,8 @@
+using CoreProtect.Domain.Entities;
+
+namespace CoreProtect.Api.Models;
+
+public sealed record UserResolutionDto(int Id, string CurrentUser, string? Uuid)
+{
+    public static UserResolutionDto FromDomain(UserResolution resolution) => new(resolution.Id, resolution.CurrentUser, resolution.Uuid);
+}

--- a/src/CoreProtect.Api/Models/UserSearchDto.cs
+++ b/src/CoreProtect.Api/Models/UserSearchDto.cs
@@ -1,0 +1,8 @@
+using CoreProtect.Domain.Entities;
+
+namespace CoreProtect.Api.Models;
+
+public sealed record UserSearchDto(int Id, string User)
+{
+    public static UserSearchDto FromDomain(UserSearchResult result) => new(result.Id, result.UserName);
+}

--- a/src/CoreProtect.Api/Models/WorldDto.cs
+++ b/src/CoreProtect.Api/Models/WorldDto.cs
@@ -1,0 +1,8 @@
+using CoreProtect.Domain.Entities;
+
+namespace CoreProtect.Api.Models;
+
+public sealed record WorldDto(int Id, string World)
+{
+    public static WorldDto FromDomain(WorldInfo info) => new(info.Id, info.Name);
+}

--- a/src/CoreProtect.Api/Program.cs
+++ b/src/CoreProtect.Api/Program.cs
@@ -1,0 +1,59 @@
+using CoreProtect.Api.Configuration;
+using CoreProtect.Api.Middleware;
+using CoreProtect.Application;
+using CoreProtect.Infrastructure;
+using Microsoft.AspNetCore.HttpLogging;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOptions<ApiSettings>()
+    .Bind(builder.Configuration.GetSection(ApiSettings.SectionName))
+    .ValidateDataAnnotations();
+
+builder.Services.AddApplication();
+builder.Services.AddInfrastructure(builder.Configuration);
+
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase;
+        options.JsonSerializerOptions.DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull;
+    });
+
+builder.Services.Configure<ApiBehaviorOptions>(options =>
+{
+    options.SuppressModelStateInvalidFilter = true;
+});
+
+builder.Services.AddHttpLogging(logging =>
+{
+    logging.LoggingFields = HttpLoggingFields.RequestMethod | HttpLoggingFields.RequestPath | HttpLoggingFields.ResponseStatusCode;
+});
+
+builder.Services.AddCors();
+builder.Services.AddHealthChecks();
+
+var app = builder.Build();
+
+var apiSettings = app.Services.GetRequiredService<IOptions<ApiSettings>>().Value;
+
+if (apiSettings.Cors.Origins.Length > 0)
+{
+    app.UseCors(policy =>
+        policy.WithOrigins(apiSettings.Cors.Origins)
+            .AllowAnyHeader()
+            .AllowAnyMethod());
+}
+
+app.UseMiddleware<ErrorHandlingMiddleware>();
+app.UseHttpLogging();
+app.UseMiddleware<ApiKeyMiddleware>();
+
+app.MapHealthChecks("/healthz");
+app.MapHealthChecks("/readyz");
+
+app.MapControllers();
+
+app.Run();

--- a/src/CoreProtect.Api/appsettings.json
+++ b/src/CoreProtect.Api/appsettings.json
@@ -1,0 +1,19 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "API": {
+    "DefaultLimit": 10,
+    "MaxLimit": 500,
+    "EnableApiKey": false,
+    "Cors": {
+      "Origins": []
+    }
+  },
+  "ConnectionStrings": {
+    "CoreProtect": "Server=localhost;Port=3306;Database=coreprotect;Uid=cp_reader;Pwd=change-me;SslMode=None"
+  }
+}

--- a/src/CoreProtect.Application/Abstractions/ICoreProtectReadRepository.cs
+++ b/src/CoreProtect.Application/Abstractions/ICoreProtectReadRepository.cs
@@ -1,0 +1,18 @@
+using CoreProtect.Application.Common;
+using CoreProtect.Domain.Entities;
+
+namespace CoreProtect.Application.Abstractions;
+
+public interface ICoreProtectReadRepository
+{
+    Task<IReadOnlyList<WorldInfo>> GetWorldsAsync(CancellationToken cancellationToken);
+    Task<IReadOnlyList<UserSearchResult>> SearchUsersAsync(string term, int limit, CancellationToken cancellationToken);
+    Task<IReadOnlyList<UserResolution>> ResolveUserAsync(string name, CancellationToken cancellationToken);
+    Task<IReadOnlyList<BlockLogEntry>> GetBlocksAsync(BlockQueryParameters parameters, CancellationToken cancellationToken);
+    Task<IReadOnlyList<ContainerLogEntry>> GetContainersAsync(ContainerQueryParameters parameters, CancellationToken cancellationToken);
+    Task<IReadOnlyList<ItemLogEntry>> GetItemsAsync(ItemQueryParameters parameters, CancellationToken cancellationToken);
+    Task<IReadOnlyList<CommandLogEntry>> GetCommandsAsync(CommandQueryParameters parameters, CancellationToken cancellationToken);
+    Task<IReadOnlyList<ChatLogEntry>> GetChatAsync(ChatQueryParameters parameters, CancellationToken cancellationToken);
+    Task<IReadOnlyList<SessionLogEntry>> GetSessionsAsync(SessionQueryParameters parameters, CancellationToken cancellationToken);
+    Task<IReadOnlyList<SignLogEntry>> GetSignsAsync(SignQueryParameters parameters, CancellationToken cancellationToken);
+}

--- a/src/CoreProtect.Application/Abstractions/IMetadataDecoder.cs
+++ b/src/CoreProtect.Application/Abstractions/IMetadataDecoder.cs
@@ -1,0 +1,8 @@
+using CoreProtect.Domain.ValueObjects;
+
+namespace CoreProtect.Application.Abstractions;
+
+public interface IMetadataDecoder
+{
+    MetadataDocument Decode(ReadOnlyMemory<byte> data);
+}

--- a/src/CoreProtect.Application/Common/BlockQueryParameters.cs
+++ b/src/CoreProtect.Application/Common/BlockQueryParameters.cs
@@ -1,0 +1,8 @@
+using CoreProtect.Domain.Entities;
+
+namespace CoreProtect.Application.Common;
+
+public sealed record BlockQueryParameters(
+    LogQueryParameters Base,
+    int? BlockTypeId,
+    BlockAction? Action);

--- a/src/CoreProtect.Application/Common/ChatQueryParameters.cs
+++ b/src/CoreProtect.Application/Common/ChatQueryParameters.cs
@@ -1,0 +1,3 @@
+namespace CoreProtect.Application.Common;
+
+public sealed record ChatQueryParameters(LogQueryParameters Base, string? MessageLike);

--- a/src/CoreProtect.Application/Common/CommandQueryParameters.cs
+++ b/src/CoreProtect.Application/Common/CommandQueryParameters.cs
@@ -1,0 +1,3 @@
+namespace CoreProtect.Application.Common;
+
+public sealed record CommandQueryParameters(LogQueryParameters Base, string? CommandLike);

--- a/src/CoreProtect.Application/Common/ContainerQueryParameters.cs
+++ b/src/CoreProtect.Application/Common/ContainerQueryParameters.cs
@@ -1,0 +1,3 @@
+namespace CoreProtect.Application.Common;
+
+public sealed record ContainerQueryParameters(LogQueryParameters Base);

--- a/src/CoreProtect.Application/Common/CoordinateFilter.cs
+++ b/src/CoreProtect.Application/Common/CoordinateFilter.cs
@@ -1,0 +1,9 @@
+namespace CoreProtect.Application.Common;
+
+public sealed record CoordinateFilter(
+    int? XMin,
+    int? XMax,
+    int? YMin,
+    int? YMax,
+    int? ZMin,
+    int? ZMax);

--- a/src/CoreProtect.Application/Common/ItemQueryParameters.cs
+++ b/src/CoreProtect.Application/Common/ItemQueryParameters.cs
@@ -1,0 +1,3 @@
+namespace CoreProtect.Application.Common;
+
+public sealed record ItemQueryParameters(LogQueryParameters Base);

--- a/src/CoreProtect.Application/Common/LogQueryParameters.cs
+++ b/src/CoreProtect.Application/Common/LogQueryParameters.cs
@@ -1,0 +1,11 @@
+namespace CoreProtect.Application.Common;
+
+public sealed record LogQueryParameters(
+    string? UserExact,
+    string? UserLike,
+    string? World,
+    long? From,
+    long? To,
+    CoordinateFilter Coordinates,
+    SortDirection SortDirection,
+    Pagination Pagination);

--- a/src/CoreProtect.Application/Common/Pagination.cs
+++ b/src/CoreProtect.Application/Common/Pagination.cs
@@ -1,0 +1,3 @@
+namespace CoreProtect.Application.Common;
+
+public sealed record Pagination(int Limit, int Offset);

--- a/src/CoreProtect.Application/Common/SessionQueryParameters.cs
+++ b/src/CoreProtect.Application/Common/SessionQueryParameters.cs
@@ -1,0 +1,3 @@
+namespace CoreProtect.Application.Common;
+
+public sealed record SessionQueryParameters(LogQueryParameters Base);

--- a/src/CoreProtect.Application/Common/SignQueryParameters.cs
+++ b/src/CoreProtect.Application/Common/SignQueryParameters.cs
@@ -1,0 +1,3 @@
+namespace CoreProtect.Application.Common;
+
+public sealed record SignQueryParameters(LogQueryParameters Base);

--- a/src/CoreProtect.Application/Common/SortDirection.cs
+++ b/src/CoreProtect.Application/Common/SortDirection.cs
@@ -1,0 +1,7 @@
+namespace CoreProtect.Application.Common;
+
+public enum SortDirection
+{
+    Ascending,
+    Descending
+}

--- a/src/CoreProtect.Application/CoreProtect.Application.csproj
+++ b/src/CoreProtect.Application/CoreProtect.Application.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../CoreProtect.Domain/CoreProtect.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/CoreProtect.Application/DependencyInjection.cs
+++ b/src/CoreProtect.Application/DependencyInjection.cs
@@ -1,0 +1,14 @@
+using CoreProtect.Application.Abstractions;
+using CoreProtect.Application.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CoreProtect.Application;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddApplication(this IServiceCollection services)
+    {
+        services.AddScoped<ICoreProtectQueryService, CoreProtectQueryService>();
+        return services;
+    }
+}

--- a/src/CoreProtect.Application/Services/CoreProtectQueryService.cs
+++ b/src/CoreProtect.Application/Services/CoreProtectQueryService.cs
@@ -1,0 +1,50 @@
+using CoreProtect.Application.Abstractions;
+using CoreProtect.Application.Common;
+using CoreProtect.Domain.Entities;
+
+namespace CoreProtect.Application.Services;
+
+public sealed class CoreProtectQueryService : ICoreProtectQueryService
+{
+    private const int UserSearchLimit = 50;
+    private readonly ICoreProtectReadRepository _repository;
+
+    public CoreProtectQueryService(ICoreProtectReadRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<IReadOnlyList<WorldInfo>> GetWorldsAsync(CancellationToken cancellationToken) =>
+        _repository.GetWorldsAsync(cancellationToken);
+
+    public Task<IReadOnlyList<UserSearchResult>> SearchUsersAsync(string term, CancellationToken cancellationToken)
+    {
+        return _repository.SearchUsersAsync(term, UserSearchLimit, cancellationToken);
+    }
+
+    public Task<IReadOnlyList<UserResolution>> ResolveUserAsync(string name, CancellationToken cancellationToken)
+    {
+        return _repository.ResolveUserAsync(name, cancellationToken);
+    }
+
+    public Task<IReadOnlyList<BlockLogEntry>> GetBlocksAsync(BlockQueryParameters parameters, CancellationToken cancellationToken) =>
+        _repository.GetBlocksAsync(parameters, cancellationToken);
+
+    public Task<IReadOnlyList<ContainerLogEntry>> GetContainersAsync(ContainerQueryParameters parameters, CancellationToken cancellationToken) =>
+        _repository.GetContainersAsync(parameters, cancellationToken);
+
+    public Task<IReadOnlyList<ItemLogEntry>> GetItemsAsync(ItemQueryParameters parameters, CancellationToken cancellationToken) =>
+        _repository.GetItemsAsync(parameters, cancellationToken);
+
+    public Task<IReadOnlyList<CommandLogEntry>> GetCommandsAsync(CommandQueryParameters parameters, CancellationToken cancellationToken) =>
+        _repository.GetCommandsAsync(parameters, cancellationToken);
+
+    public Task<IReadOnlyList<ChatLogEntry>> GetChatAsync(ChatQueryParameters parameters, CancellationToken cancellationToken) =>
+        _repository.GetChatAsync(parameters, cancellationToken);
+
+    public Task<IReadOnlyList<SessionLogEntry>> GetSessionsAsync(SessionQueryParameters parameters, CancellationToken cancellationToken) =>
+        _repository.GetSessionsAsync(parameters, cancellationToken);
+
+    public Task<IReadOnlyList<SignLogEntry>> GetSignsAsync(SignQueryParameters parameters, CancellationToken cancellationToken) =>
+        _repository.GetSignsAsync(parameters, cancellationToken);
+}

--- a/src/CoreProtect.Application/Services/ICoreProtectQueryService.cs
+++ b/src/CoreProtect.Application/Services/ICoreProtectQueryService.cs
@@ -1,0 +1,18 @@
+using CoreProtect.Application.Common;
+using CoreProtect.Domain.Entities;
+
+namespace CoreProtect.Application.Services;
+
+public interface ICoreProtectQueryService
+{
+    Task<IReadOnlyList<WorldInfo>> GetWorldsAsync(CancellationToken cancellationToken);
+    Task<IReadOnlyList<UserSearchResult>> SearchUsersAsync(string term, CancellationToken cancellationToken);
+    Task<IReadOnlyList<UserResolution>> ResolveUserAsync(string name, CancellationToken cancellationToken);
+    Task<IReadOnlyList<BlockLogEntry>> GetBlocksAsync(BlockQueryParameters parameters, CancellationToken cancellationToken);
+    Task<IReadOnlyList<ContainerLogEntry>> GetContainersAsync(ContainerQueryParameters parameters, CancellationToken cancellationToken);
+    Task<IReadOnlyList<ItemLogEntry>> GetItemsAsync(ItemQueryParameters parameters, CancellationToken cancellationToken);
+    Task<IReadOnlyList<CommandLogEntry>> GetCommandsAsync(CommandQueryParameters parameters, CancellationToken cancellationToken);
+    Task<IReadOnlyList<ChatLogEntry>> GetChatAsync(ChatQueryParameters parameters, CancellationToken cancellationToken);
+    Task<IReadOnlyList<SessionLogEntry>> GetSessionsAsync(SessionQueryParameters parameters, CancellationToken cancellationToken);
+    Task<IReadOnlyList<SignLogEntry>> GetSignsAsync(SignQueryParameters parameters, CancellationToken cancellationToken);
+}

--- a/src/CoreProtect.Domain/CoreProtect.Domain.csproj
+++ b/src/CoreProtect.Domain/CoreProtect.Domain.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/src/CoreProtect.Domain/Entities/BlockLogEntry.cs
+++ b/src/CoreProtect.Domain/Entities/BlockLogEntry.cs
@@ -1,0 +1,20 @@
+using CoreProtect.Domain.ValueObjects;
+
+namespace CoreProtect.Domain.Entities;
+
+public enum BlockAction
+{
+    Placed,
+    Broken
+}
+
+public sealed record BlockLogEntry(
+    long Time,
+    DateTimeOffset Timestamp,
+    string User,
+    string World,
+    Coordinates Coordinates,
+    BlockAction Action,
+    int BlockTypeId,
+    string? BlockTypeName,
+    bool RolledBack);

--- a/src/CoreProtect.Domain/Entities/ChatLogEntry.cs
+++ b/src/CoreProtect.Domain/Entities/ChatLogEntry.cs
@@ -1,0 +1,11 @@
+using CoreProtect.Domain.ValueObjects;
+
+namespace CoreProtect.Domain.Entities;
+
+public sealed record ChatLogEntry(
+    long Time,
+    DateTimeOffset Timestamp,
+    string User,
+    string World,
+    Coordinates Coordinates,
+    string Message);

--- a/src/CoreProtect.Domain/Entities/CommandLogEntry.cs
+++ b/src/CoreProtect.Domain/Entities/CommandLogEntry.cs
@@ -1,0 +1,11 @@
+using CoreProtect.Domain.ValueObjects;
+
+namespace CoreProtect.Domain.Entities;
+
+public sealed record CommandLogEntry(
+    long Time,
+    DateTimeOffset Timestamp,
+    string User,
+    string World,
+    Coordinates Coordinates,
+    string Command);

--- a/src/CoreProtect.Domain/Entities/ContainerLogEntry.cs
+++ b/src/CoreProtect.Domain/Entities/ContainerLogEntry.cs
@@ -1,0 +1,22 @@
+using CoreProtect.Domain.ValueObjects;
+
+namespace CoreProtect.Domain.Entities;
+
+public enum ContainerAction
+{
+    Put,
+    Took
+}
+
+public sealed record ContainerLogEntry(
+    long Time,
+    DateTimeOffset Timestamp,
+    string User,
+    string World,
+    Coordinates Coordinates,
+    ContainerAction Action,
+    int ItemTypeId,
+    int ItemData,
+    int Amount,
+    MetadataDocument Metadata,
+    bool RolledBack);

--- a/src/CoreProtect.Domain/Entities/ItemLogEntry.cs
+++ b/src/CoreProtect.Domain/Entities/ItemLogEntry.cs
@@ -1,0 +1,22 @@
+using CoreProtect.Domain.ValueObjects;
+
+namespace CoreProtect.Domain.Entities;
+
+public enum ItemAction
+{
+    Drop,
+    Pickup,
+    Unknown
+}
+
+public sealed record ItemLogEntry(
+    long Time,
+    DateTimeOffset Timestamp,
+    string User,
+    string World,
+    Coordinates Coordinates,
+    ItemAction Action,
+    int ItemTypeId,
+    int ItemData,
+    int Amount,
+    bool RolledBack);

--- a/src/CoreProtect.Domain/Entities/SessionLogEntry.cs
+++ b/src/CoreProtect.Domain/Entities/SessionLogEntry.cs
@@ -1,0 +1,17 @@
+using CoreProtect.Domain.ValueObjects;
+
+namespace CoreProtect.Domain.Entities;
+
+public enum SessionAction
+{
+    Login,
+    Logout
+}
+
+public sealed record SessionLogEntry(
+    long Time,
+    DateTimeOffset Timestamp,
+    string User,
+    string World,
+    Coordinates Coordinates,
+    SessionAction Action);

--- a/src/CoreProtect.Domain/Entities/SignLogEntry.cs
+++ b/src/CoreProtect.Domain/Entities/SignLogEntry.cs
@@ -1,0 +1,14 @@
+using CoreProtect.Domain.ValueObjects;
+
+namespace CoreProtect.Domain.Entities;
+
+public sealed record SignLogEntry(
+    long Time,
+    DateTimeOffset Timestamp,
+    string User,
+    string World,
+    Coordinates Coordinates,
+    string Action,
+    string? Color,
+    string? GlowingText,
+    IReadOnlyList<string> Lines);

--- a/src/CoreProtect.Domain/Entities/UserResolution.cs
+++ b/src/CoreProtect.Domain/Entities/UserResolution.cs
@@ -1,0 +1,3 @@
+namespace CoreProtect.Domain.Entities;
+
+public sealed record UserResolution(int Id, string CurrentUser, string? Uuid);

--- a/src/CoreProtect.Domain/Entities/UserSearchResult.cs
+++ b/src/CoreProtect.Domain/Entities/UserSearchResult.cs
@@ -1,0 +1,3 @@
+namespace CoreProtect.Domain.Entities;
+
+public sealed record UserSearchResult(int Id, string UserName);

--- a/src/CoreProtect.Domain/Entities/WorldInfo.cs
+++ b/src/CoreProtect.Domain/Entities/WorldInfo.cs
@@ -1,0 +1,3 @@
+namespace CoreProtect.Domain.Entities;
+
+public sealed record WorldInfo(int Id, string Name);

--- a/src/CoreProtect.Domain/ValueObjects/Coordinates.cs
+++ b/src/CoreProtect.Domain/ValueObjects/Coordinates.cs
@@ -1,0 +1,3 @@
+namespace CoreProtect.Domain.ValueObjects;
+
+public readonly record struct Coordinates(int X, int Y, int Z);

--- a/src/CoreProtect.Domain/ValueObjects/MetadataDocument.cs
+++ b/src/CoreProtect.Domain/ValueObjects/MetadataDocument.cs
@@ -1,0 +1,6 @@
+namespace CoreProtect.Domain.ValueObjects;
+
+public sealed record MetadataDocument(object? Json, string? RawHex, string? Base64)
+{
+    public static MetadataDocument Empty { get; } = new(null, null, null);
+}

--- a/src/CoreProtect.Infrastructure/Configuration/CoreProtectDatabaseOptions.cs
+++ b/src/CoreProtect.Infrastructure/Configuration/CoreProtectDatabaseOptions.cs
@@ -1,0 +1,8 @@
+namespace CoreProtect.Infrastructure.Configuration;
+
+public sealed class CoreProtectDatabaseOptions
+{
+    public const string SectionName = "ConnectionStrings";
+    public string CoreProtect { get; init; } = string.Empty;
+    public TimeSpan CommandTimeout { get; init; } = TimeSpan.FromSeconds(5);
+}

--- a/src/CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj
+++ b/src/CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../CoreProtect.Application/CoreProtect.Application.csproj" />
+    <ProjectReference Include="../CoreProtect.Domain/CoreProtect.Domain.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="MySqlConnector" Version="2.3.7" />
+    <PackageReference Include="SharpNBT" Version="2.0.1" />
+  </ItemGroup>
+</Project>

--- a/src/CoreProtect.Infrastructure/Data/CoreProtectReadRepository.cs
+++ b/src/CoreProtect.Infrastructure/Data/CoreProtectReadRepository.cs
@@ -1,0 +1,329 @@
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics;
+using CoreProtect.Application.Abstractions;
+using CoreProtect.Application.Common;
+using CoreProtect.Domain.Entities;
+using CoreProtect.Domain.ValueObjects;
+using CoreProtect.Infrastructure.Configuration;
+using Dapper;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CoreProtect.Infrastructure.Data;
+
+public sealed class CoreProtectReadRepository : ICoreProtectReadRepository
+{
+    private const string UserCte = @"WITH user_ids AS (
+  SELECT id
+  FROM co_user
+  WHERE user = COALESCE(@userExact, user)
+    AND user LIKE COALESCE(@userLike, user) COLLATE utf8mb4_general_ci
+  UNION
+  SELECT u.id
+  FROM co_username_log ul
+  JOIN co_user u ON u.uuid = ul.uuid
+  WHERE ul.user LIKE COALESCE(@userLike, ul.user) COLLATE utf8mb4_general_ci
+     OR ul.user = COALESCE(@userExact, ul.user)
+)";
+
+    private readonly IDbConnectionFactory _connectionFactory;
+    private readonly IMetadataDecoder _metadataDecoder;
+    private readonly ILogger<CoreProtectReadRepository> _logger;
+    private readonly IOptionsMonitor<CoreProtectDatabaseOptions> _options;
+
+    public CoreProtectReadRepository(
+        IDbConnectionFactory connectionFactory,
+        IMetadataDecoder metadataDecoder,
+        ILogger<CoreProtectReadRepository> logger,
+        IOptionsMonitor<CoreProtectDatabaseOptions> options)
+    {
+        _connectionFactory = connectionFactory;
+        _metadataDecoder = metadataDecoder;
+        _logger = logger;
+        _options = options;
+    }
+
+    public async Task<IReadOnlyList<WorldInfo>> GetWorldsAsync(CancellationToken cancellationToken)
+    {
+        const string sql = "SELECT id, world FROM co_world ORDER BY world";
+        return await QueryAsync(sql, new DynamicParameters(), MapWorld, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<UserSearchResult>> SearchUsersAsync(string term, int limit, CancellationToken cancellationToken)
+    {
+        const string sql = "SELECT id, user AS user_name FROM co_user WHERE user LIKE @pattern COLLATE utf8mb4_general_ci ORDER BY user LIMIT @limit";
+        var parameters = new DynamicParameters();
+        parameters.Add("@pattern", $"%{term}%");
+        parameters.Add("@limit", limit);
+        return await QueryAsync(sql, parameters, MapUserSearch, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<UserResolution>> ResolveUserAsync(string name, CancellationToken cancellationToken)
+    {
+        const string sql = @"WITH name_history AS (
+    SELECT u.id, u.user AS current_user, u.uuid, u.time
+    FROM co_user u
+    WHERE u.user = @name
+    UNION
+    SELECT u.id, u.user AS current_user, u.uuid, u.time
+    FROM co_username_log ul
+    JOIN co_user u ON u.uuid = ul.uuid
+    WHERE ul.user = @name
+)
+SELECT DISTINCT id, current_user, uuid FROM name_history ORDER BY time DESC";
+        var parameters = new DynamicParameters();
+        parameters.Add("@name", name);
+        return await QueryAsync(sql, parameters, MapUserResolution, cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task<IReadOnlyList<BlockLogEntry>> GetBlocksAsync(BlockQueryParameters parameters, CancellationToken cancellationToken)
+    {
+        var sql = $"{UserCte}\nSELECT b.time, u.user AS user_name, w.world, b.x, b.y, b.z, b.action, b.type, mm.material, b.rolled_back\nFROM co_block b\nJOIN co_user u ON u.id = b.user\nJOIN co_world w ON w.id = b.wid\nLEFT JOIN co_material_map mm ON mm.id = b.type\nWHERE {BuildBaseFilter("b", "w", parameters.Base)}\n  AND b.type = COALESCE(@blockTypeId, b.type)\n  AND b.action = COALESCE(@blockAction, b.action)\nORDER BY b.time {ToSqlOrder(parameters.Base.SortDirection)}\nLIMIT @limit OFFSET @offset";
+
+        var dapperParameters = BuildBaseParameters(parameters.Base);
+        dapperParameters.Add("@blockTypeId", parameters.BlockTypeId);
+        dapperParameters.Add("@blockAction", parameters.Action.HasValue ? (int?)ConvertBlockAction(parameters.Action.Value) : null);
+
+        return QueryAsync(sql, dapperParameters, MapBlock, cancellationToken);
+    }
+
+    public Task<IReadOnlyList<ContainerLogEntry>> GetContainersAsync(ContainerQueryParameters parameters, CancellationToken cancellationToken)
+    {
+        var sql = $"{UserCte}\nSELECT c.time, u.user AS user_name, w.world, c.x, c.y, c.z, c.action, c.type, c.data, c.amount, c.metadata, c.rolled_back\nFROM co_container c\nJOIN co_user u ON u.id = c.user\nJOIN co_world w ON w.id = c.wid\nWHERE {BuildBaseFilter("c", "w", parameters.Base)}\nORDER BY c.time {ToSqlOrder(parameters.Base.SortDirection)}\nLIMIT @limit OFFSET @offset";
+
+        var dapperParameters = BuildBaseParameters(parameters.Base);
+        return QueryAsync(sql, dapperParameters, MapContainer, cancellationToken);
+    }
+
+    public Task<IReadOnlyList<ItemLogEntry>> GetItemsAsync(ItemQueryParameters parameters, CancellationToken cancellationToken)
+    {
+        var sql = $"{UserCte}\nSELECT i.time, u.user AS user_name, w.world, i.x, i.y, i.z, i.action, i.type, i.data, i.amount, i.rolled_back\nFROM co_item i\nJOIN co_user u ON u.id = i.user\nJOIN co_world w ON w.id = i.wid\nWHERE {BuildBaseFilter("i", "w", parameters.Base)}\nORDER BY i.time {ToSqlOrder(parameters.Base.SortDirection)}\nLIMIT @limit OFFSET @offset";
+
+        var dapperParameters = BuildBaseParameters(parameters.Base);
+        return QueryAsync(sql, dapperParameters, MapItem, cancellationToken);
+    }
+
+    public Task<IReadOnlyList<CommandLogEntry>> GetCommandsAsync(CommandQueryParameters parameters, CancellationToken cancellationToken)
+    {
+        var sql = $"{UserCte}\nSELECT c.time, u.user AS user_name, w.world, c.x, c.y, c.z, c.message\nFROM co_command c\nJOIN co_user u ON u.id = c.user\nJOIN co_world w ON w.id = c.wid\nWHERE {BuildBaseFilter("c", "w", parameters.Base)}\n  AND c.message LIKE COALESCE(@commandLike, c.message) COLLATE utf8mb4_general_ci\nORDER BY c.time {ToSqlOrder(parameters.Base.SortDirection)}\nLIMIT @limit OFFSET @offset";
+
+        var dapperParameters = BuildBaseParameters(parameters.Base);
+        dapperParameters.Add("@commandLike", parameters.CommandLike);
+        return QueryAsync(sql, dapperParameters, MapCommand, cancellationToken);
+    }
+
+    public Task<IReadOnlyList<ChatLogEntry>> GetChatAsync(ChatQueryParameters parameters, CancellationToken cancellationToken)
+    {
+        var sql = $"{UserCte}\nSELECT ch.time, u.user AS user_name, w.world, ch.x, ch.y, ch.z, ch.message\nFROM co_chat ch\nJOIN co_user u ON u.id = ch.user\nJOIN co_world w ON w.id = ch.wid\nWHERE {BuildBaseFilter("ch", "w", parameters.Base)}\n  AND ch.message LIKE COALESCE(@messageLike, ch.message) COLLATE utf8mb4_general_ci\nORDER BY ch.time {ToSqlOrder(parameters.Base.SortDirection)}\nLIMIT @limit OFFSET @offset";
+
+        var dapperParameters = BuildBaseParameters(parameters.Base);
+        dapperParameters.Add("@messageLike", parameters.MessageLike);
+        return QueryAsync(sql, dapperParameters, MapChat, cancellationToken);
+    }
+
+    public Task<IReadOnlyList<SessionLogEntry>> GetSessionsAsync(SessionQueryParameters parameters, CancellationToken cancellationToken)
+    {
+        var sql = $"{UserCte}\nSELECT s.time, u.user AS user_name, w.world, s.x, s.y, s.z, s.action\nFROM co_session s\nJOIN co_user u ON u.id = s.user\nJOIN co_world w ON w.id = s.wid\nWHERE {BuildBaseFilter("s", "w", parameters.Base)}\nORDER BY s.time {ToSqlOrder(parameters.Base.SortDirection)}\nLIMIT @limit OFFSET @offset";
+
+        var dapperParameters = BuildBaseParameters(parameters.Base);
+        return QueryAsync(sql, dapperParameters, MapSession, cancellationToken);
+    }
+
+    public Task<IReadOnlyList<SignLogEntry>> GetSignsAsync(SignQueryParameters parameters, CancellationToken cancellationToken)
+    {
+        var sql = $"{UserCte}\nSELECT sg.time, u.user AS user_name, w.world, sg.x, sg.y, sg.z, sg.action, sg.color, sg.glow, sg.line_1, sg.line_2, sg.line_3, sg.line_4, sg.line_5, sg.line_6, sg.line_7, sg.line_8\nFROM co_sign sg\nJOIN co_user u ON u.id = sg.user\nJOIN co_world w ON w.id = sg.wid\nWHERE {BuildBaseFilter("sg", "w", parameters.Base)}\nORDER BY sg.time {ToSqlOrder(parameters.Base.SortDirection)}\nLIMIT @limit OFFSET @offset";
+
+        var dapperParameters = BuildBaseParameters(parameters.Base);
+        return QueryAsync(sql, dapperParameters, MapSign, cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<T>> QueryAsync<T>(
+        string sql,
+        DynamicParameters parameters,
+        Func<IDataRecord, T> projector,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        var stopwatch = Stopwatch.StartNew();
+        await using var reader = await connection.ExecuteReaderAsync(sql, parameters, commandTimeout: (int)_options.CurrentValue.CommandTimeout.TotalSeconds).ConfigureAwait(false);
+
+        var result = new List<T>();
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            result.Add(projector(reader));
+        }
+
+        stopwatch.Stop();
+        if (stopwatch.Elapsed > TimeSpan.FromMilliseconds(500))
+        {
+            _logger.LogWarning("Slow SQL query detected ({ElapsedMilliseconds} ms): {Sql}", stopwatch.Elapsed.TotalMilliseconds, sql);
+        }
+
+        return result;
+    }
+
+    private static Func<IDataRecord, WorldInfo> MapWorld => record => new WorldInfo(record.GetInt32(0), record.GetString(1));
+
+    private static Func<IDataRecord, UserSearchResult> MapUserSearch => record =>
+        new UserSearchResult(record.GetInt32(0), record.GetString(1));
+
+    private static Func<IDataRecord, UserResolution> MapUserResolution => record =>
+        new UserResolution(record.GetInt32(0), record.GetString(1), record.IsDBNull(2) ? null : record.GetString(2));
+
+    private BlockLogEntry MapBlock(IDataRecord record)
+    {
+        var action = record.GetInt32(6) == 0 ? BlockAction.Placed : BlockAction.Broken;
+        var timestamp = DateTimeOffset.FromUnixTimeSeconds(record.GetInt64(0));
+        return new BlockLogEntry(
+            record.GetInt64(0),
+            timestamp,
+            record.GetString(1),
+            record.GetString(2),
+            new Coordinates(record.GetInt32(3), record.GetInt32(4), record.GetInt32(5)),
+            action,
+            record.GetInt32(7),
+            record.IsDBNull(8) ? null : record.GetString(8),
+            record.GetBoolean(9));
+    }
+
+    private ContainerLogEntry MapContainer(IDataRecord record)
+    {
+        var timestamp = DateTimeOffset.FromUnixTimeSeconds(record.GetInt64(0));
+        var metadata = MetadataDocument.Empty;
+        if (!record.IsDBNull(10))
+        {
+            var raw = (byte[])record.GetValue(10);
+            metadata = _metadataDecoder.Decode(raw);
+        }
+
+        var action = record.GetInt32(6) == 0 ? ContainerAction.Put : ContainerAction.Took;
+        return new ContainerLogEntry(
+            record.GetInt64(0),
+            timestamp,
+            record.GetString(1),
+            record.GetString(2),
+            new Coordinates(record.GetInt32(3), record.GetInt32(4), record.GetInt32(5)),
+            action,
+            record.GetInt32(7),
+            record.GetInt32(8),
+            record.GetInt32(9),
+            metadata,
+            record.GetBoolean(11));
+    }
+
+    private ItemLogEntry MapItem(IDataRecord record)
+    {
+        var timestamp = DateTimeOffset.FromUnixTimeSeconds(record.GetInt64(0));
+        var actionValue = record.GetInt32(6);
+        var action = actionValue switch
+        {
+            0 => ItemAction.Drop,
+            1 => ItemAction.Pickup,
+            _ => ItemAction.Unknown
+        };
+
+        return new ItemLogEntry(
+            record.GetInt64(0),
+            timestamp,
+            record.GetString(1),
+            record.GetString(2),
+            new Coordinates(record.GetInt32(3), record.GetInt32(4), record.GetInt32(5)),
+            action,
+            record.GetInt32(7),
+            record.GetInt32(8),
+            record.GetInt32(9),
+            record.GetBoolean(10));
+    }
+
+    private CommandLogEntry MapCommand(IDataRecord record)
+    {
+        var timestamp = DateTimeOffset.FromUnixTimeSeconds(record.GetInt64(0));
+        return new CommandLogEntry(
+            record.GetInt64(0),
+            timestamp,
+            record.GetString(1),
+            record.GetString(2),
+            new Coordinates(record.GetInt32(3), record.GetInt32(4), record.GetInt32(5)),
+            record.GetString(6));
+    }
+
+    private ChatLogEntry MapChat(IDataRecord record)
+    {
+        var timestamp = DateTimeOffset.FromUnixTimeSeconds(record.GetInt64(0));
+        return new ChatLogEntry(
+            record.GetInt64(0),
+            timestamp,
+            record.GetString(1),
+            record.GetString(2),
+            new Coordinates(record.GetInt32(3), record.GetInt32(4), record.GetInt32(5)),
+            record.GetString(6));
+    }
+
+    private SessionLogEntry MapSession(IDataRecord record)
+    {
+        var timestamp = DateTimeOffset.FromUnixTimeSeconds(record.GetInt64(0));
+        var action = record.GetInt32(6) == 0 ? SessionAction.Login : SessionAction.Logout;
+        return new SessionLogEntry(
+            record.GetInt64(0),
+            timestamp,
+            record.GetString(1),
+            record.GetString(2),
+            new Coordinates(record.GetInt32(3), record.GetInt32(4), record.GetInt32(5)),
+            action);
+    }
+
+    private SignLogEntry MapSign(IDataRecord record)
+    {
+        var timestamp = DateTimeOffset.FromUnixTimeSeconds(record.GetInt64(0));
+        var lines = new List<string>(8);
+        for (var i = 9; i <= 16; i++)
+        {
+            lines.Add(record.IsDBNull(i) ? string.Empty : record.GetString(i));
+        }
+
+        return new SignLogEntry(
+            record.GetInt64(0),
+            timestamp,
+            record.GetString(1),
+            record.GetString(2),
+            new Coordinates(record.GetInt32(3), record.GetInt32(4), record.GetInt32(5)),
+            record.GetString(6),
+            record.IsDBNull(7) ? null : record.GetString(7),
+            record.IsDBNull(8) ? null : record.GetString(8),
+            lines);
+    }
+
+    private static int ConvertBlockAction(BlockAction action) => action switch
+    {
+        BlockAction.Placed => 0,
+        BlockAction.Broken => 1,
+        _ => throw new ArgumentOutOfRangeException(nameof(action), action, null)
+    };
+
+    private static string BuildBaseFilter(string tableAlias, string worldAlias, LogQueryParameters parameters)
+    {
+        return $"(COALESCE(@userExact, @userLike) IS NULL OR {tableAlias}.user IN (SELECT id FROM user_ids)) AND\n  {tableAlias}.time >= COALESCE(@from, 0) AND\n  {tableAlias}.time < COALESCE(@to, 9223372036854775807) AND\n  {tableAlias}.x BETWEEN COALESCE(@xMin, -2147483648) AND COALESCE(@xMax, 2147483647) AND\n  {tableAlias}.y BETWEEN COALESCE(@yMin, -2147483648) AND COALESCE(@yMax, 2147483647) AND\n  {tableAlias}.z BETWEEN COALESCE(@zMin, -2147483648) AND COALESCE(@zMax, 2147483647) AND\n  {worldAlias}.world = COALESCE(@world, {worldAlias}.world)";
+    }
+
+    private static DynamicParameters BuildBaseParameters(LogQueryParameters parameters)
+    {
+        var dp = new DynamicParameters();
+        dp.Add("@userExact", parameters.UserExact);
+        dp.Add("@userLike", parameters.UserLike);
+        dp.Add("@world", parameters.World);
+        dp.Add("@from", parameters.From);
+        dp.Add("@to", parameters.To);
+        dp.Add("@xMin", parameters.Coordinates.XMin);
+        dp.Add("@xMax", parameters.Coordinates.XMax);
+        dp.Add("@yMin", parameters.Coordinates.YMin);
+        dp.Add("@yMax", parameters.Coordinates.YMax);
+        dp.Add("@zMin", parameters.Coordinates.ZMin);
+        dp.Add("@zMax", parameters.Coordinates.ZMax);
+        dp.Add("@limit", parameters.Pagination.Limit);
+        dp.Add("@offset", parameters.Pagination.Offset);
+        return dp;
+    }
+
+    private static string ToSqlOrder(SortDirection direction) => direction == SortDirection.Ascending ? "ASC" : "DESC";
+}

--- a/src/CoreProtect.Infrastructure/Data/IDbConnectionFactory.cs
+++ b/src/CoreProtect.Infrastructure/Data/IDbConnectionFactory.cs
@@ -1,0 +1,8 @@
+using MySqlConnector;
+
+namespace CoreProtect.Infrastructure.Data;
+
+public interface IDbConnectionFactory
+{
+    ValueTask<MySqlConnection> CreateOpenConnectionAsync(CancellationToken cancellationToken);
+}

--- a/src/CoreProtect.Infrastructure/Data/MySqlConnectionFactory.cs
+++ b/src/CoreProtect.Infrastructure/Data/MySqlConnectionFactory.cs
@@ -1,0 +1,32 @@
+using CoreProtect.Infrastructure.Configuration;
+using Microsoft.Extensions.Options;
+using MySqlConnector;
+
+namespace CoreProtect.Infrastructure.Data;
+
+public sealed class MySqlConnectionFactory : IDbConnectionFactory
+{
+    private readonly IOptionsMonitor<CoreProtectDatabaseOptions> _options;
+
+    public MySqlConnectionFactory(IOptionsMonitor<CoreProtectDatabaseOptions> options)
+    {
+        _options = options;
+    }
+
+    public async ValueTask<MySqlConnection> CreateOpenConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connectionString = _options.CurrentValue.CoreProtect;
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new InvalidOperationException("CoreProtect connection string is not configured.");
+        }
+
+        var connection = new MySqlConnection(connectionString)
+        {
+            ConnectionTimeout = (uint)_options.CurrentValue.CommandTimeout.TotalSeconds
+        };
+
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return connection;
+    }
+}

--- a/src/CoreProtect.Infrastructure/Decoding/JavaSerializationParser.cs
+++ b/src/CoreProtect.Infrastructure/Decoding/JavaSerializationParser.cs
@@ -1,0 +1,520 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using CoreProtect.Domain.ValueObjects;
+
+namespace CoreProtect.Infrastructure.Decoding;
+
+internal sealed class JavaSerializationParser
+{
+    private const ushort StreamMagic = 0xACED;
+    private const ushort StreamVersion = 0x0005;
+    private const int HandleBase = 0x7E0000;
+
+    private readonly ReadOnlyMemory<byte> _data;
+    private readonly List<object?> _handles = new();
+    private int _position;
+
+    public JavaSerializationParser(ReadOnlyMemory<byte> data)
+    {
+        _data = data;
+    }
+
+    public bool TryParse(out object? result)
+    {
+        result = null;
+        if (_data.Length < 4)
+        {
+            return false;
+        }
+
+        if (!ReadStreamHeader())
+        {
+            return false;
+        }
+
+        try
+        {
+            result = ReadContent();
+            return result is not null;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private bool ReadStreamHeader()
+    {
+        var magic = ReadUInt16();
+        var version = ReadUInt16();
+        return magic == StreamMagic && version == StreamVersion;
+    }
+
+    private object? ReadContent()
+    {
+        var token = ReadByte();
+        return token switch
+        {
+            JavaTokens.Null => null,
+            JavaTokens.Reference => ReadReference(),
+            JavaTokens.Object => ReadNewObject(),
+            JavaTokens.String => ReadNewString(),
+            JavaTokens.LongString => ReadNewLongString(),
+            JavaTokens.Array => ReadNewArray(),
+            JavaTokens.Enum => ReadEnum(),
+            JavaTokens.ClassDesc => ReadClassDesc(),
+            _ => throw new NotSupportedException($"Unsupported Java serialization token: 0x{token:X2}")
+        };
+    }
+
+    private object? ReadReference()
+    {
+        var handle = ReadInt32();
+        var index = handle - HandleBase;
+        return index >= 0 && index < _handles.Count ? _handles[index] : null;
+    }
+
+    private JavaClassDescriptor? ReadClassDesc()
+    {
+        var token = ReadByte();
+        if (token == JavaTokens.Null)
+        {
+            return null;
+        }
+
+        if (token == JavaTokens.Reference)
+        {
+            var handle = ReadInt32();
+            return (JavaClassDescriptor?)_handles[handle - HandleBase];
+        }
+
+        if (token != JavaTokens.ClassDesc)
+        {
+            throw new NotSupportedException($"Unsupported class descriptor token: 0x{token:X2}");
+        }
+
+        var handleIndex = RegisterPlaceholder();
+        var name = ReadUtf();
+        var serialVersion = ReadInt64();
+        var flags = ReadByte();
+        var fieldCount = ReadUInt16();
+        var fields = new JavaFieldDescriptor[fieldCount];
+        for (var i = 0; i < fieldCount; i++)
+        {
+            var typeCode = ReadByte();
+            var fieldName = ReadUtf();
+            string? className = null;
+            if (typeCode is (byte)'L' or (byte)'[')
+            {
+                className = ReadUtf();
+            }
+
+            fields[i] = new JavaFieldDescriptor((char)typeCode, fieldName, className);
+        }
+
+        SkipClassAnnotations();
+        var superClass = ReadClassDesc();
+
+        var descriptor = new JavaClassDescriptor(name, serialVersion, flags, fields, superClass);
+        SetHandle(handleIndex, descriptor);
+        return descriptor;
+    }
+
+    private void SkipClassAnnotations()
+    {
+        while (true)
+        {
+            var token = ReadByte();
+            if (token == JavaTokens.EndBlockData)
+            {
+                return;
+            }
+
+            _position--; // unread
+            ReadContent();
+        }
+    }
+
+    private object? ReadNewObject()
+    {
+        var classDesc = ReadClassDesc();
+        if (classDesc is null)
+        {
+            return null;
+        }
+
+        var handleIndex = RegisterPlaceholder();
+        object? instance = classDesc.Name switch
+        {
+            "java.util.HashMap" => ReadHashMap(classDesc),
+            "java.util.LinkedHashMap" => ReadHashMap(classDesc),
+            "java.util.TreeMap" => ReadHashMap(classDesc),
+            "java.util.EnumMap" => ReadHashMap(classDesc),
+            "java.util.ArrayList" => ReadArrayList(classDesc),
+            "java.util.LinkedList" => ReadArrayList(classDesc),
+            "java.util.Collections$UnmodifiableMap" => ReadMapWrapper(classDesc),
+            "java.util.Collections$SingletonMap" => ReadSingletonMap(classDesc),
+            "com.google.common.collect.ImmutableMap$SerializedForm" => ReadImmutableMap(classDesc),
+            _ => ReadPojo(classDesc)
+        };
+
+        SetHandle(handleIndex, instance);
+        return instance;
+    }
+
+    private object? ReadPojo(JavaClassDescriptor classDesc)
+    {
+        var state = ReadClassDataHierarchy(classDesc);
+        return state;
+    }
+
+    private Dictionary<string, object?> ReadClassDataHierarchy(JavaClassDescriptor descriptor)
+    {
+        var state = descriptor.SuperClass is null
+            ? new Dictionary<string, object?>(StringComparer.Ordinal)
+            : ReadClassDataHierarchy(descriptor.SuperClass);
+
+        foreach (var field in descriptor.Fields)
+        {
+            state[field.Name] = ReadFieldValue(field);
+        }
+
+        if (descriptor.HasWriteMethod)
+        {
+            SkipOptionalBlockData();
+        }
+
+        return state;
+    }
+
+    private IDictionary<string, object?> ReadHashMap(JavaClassDescriptor descriptor)
+    {
+        var state = ReadClassDataHierarchy(descriptor);
+        var size = ReadInt32();
+        var map = new Dictionary<string, object?>(size, StringComparer.Ordinal);
+        for (var i = 0; i < size; i++)
+        {
+            var key = ReadContent();
+            var value = ReadContent();
+            if (key is null)
+            {
+                continue;
+            }
+
+            map[Convert.ToString(key, CultureInfo.InvariantCulture) ?? string.Empty] = value;
+        }
+
+        return map;
+    }
+
+    private IDictionary<string, object?> ReadSingletonMap(JavaClassDescriptor descriptor)
+    {
+        var state = ReadClassDataHierarchy(descriptor);
+        var map = new Dictionary<string, object?>(1, StringComparer.Ordinal);
+        if (state.TryGetValue("key", out var key) && key is not null)
+        {
+            map[Convert.ToString(key, CultureInfo.InvariantCulture) ?? string.Empty] = state.TryGetValue("value", out var value) ? value : null;
+        }
+
+        return map;
+    }
+
+    private IDictionary<string, object?> ReadMapWrapper(JavaClassDescriptor descriptor)
+    {
+        var state = ReadClassDataHierarchy(descriptor);
+        if (state.TryGetValue("m", out var inner) && inner is IDictionary<string, object?> dictionary)
+        {
+            return dictionary;
+        }
+
+        return new Dictionary<string, object?>();
+    }
+
+    private object ReadImmutableMap(JavaClassDescriptor descriptor)
+    {
+        var state = ReadClassDataHierarchy(descriptor);
+        if (!state.TryGetValue("keys", out var keys) || keys is not IList keyList)
+        {
+            return state;
+        }
+
+        if (!state.TryGetValue("values", out var values) || values is not IList valueList)
+        {
+            return state;
+        }
+
+        var map = new Dictionary<string, object?>(keyList.Count, StringComparer.Ordinal);
+        for (var i = 0; i < keyList.Count; i++)
+        {
+            var key = keyList[i];
+            if (key is null)
+            {
+                continue;
+            }
+
+            var keyString = Convert.ToString(key, CultureInfo.InvariantCulture) ?? string.Empty;
+            var value = i < valueList.Count ? valueList[i] : null;
+            map[keyString] = value;
+        }
+
+        return map;
+    }
+
+    private IList<object?> ReadArrayList(JavaClassDescriptor descriptor)
+    {
+        var state = ReadClassDataHierarchy(descriptor);
+        var size = state.TryGetValue("size", out var sizeValue) ? Convert.ToInt32(sizeValue, CultureInfo.InvariantCulture) : 0;
+        var list = new List<object?>(size);
+        RegisterHandle(list);
+        for (var i = 0; i < size; i++)
+        {
+            list.Add(ReadContent());
+        }
+
+        return list;
+    }
+
+    private void SkipOptionalBlockData()
+    {
+        while (_position < _data.Length)
+        {
+            var marker = _data.Span[_position];
+            if (marker == JavaTokens.EndBlockData)
+            {
+                _position++;
+                continue;
+            }
+
+            if (marker == JavaTokens.BlockData)
+            {
+                _position++;
+                var length = ReadByte();
+                _position += length;
+                continue;
+            }
+
+            if (marker == JavaTokens.BlockDataLong)
+            {
+                _position++;
+                var length = ReadInt32();
+                _position += length;
+                continue;
+            }
+
+            break;
+        }
+    }
+
+    private object? ReadFieldValue(JavaFieldDescriptor field)
+    {
+        return field.TypeCode switch
+        {
+            'B' => (sbyte)ReadByte(),
+            'C' => (char)ReadUInt16(),
+            'D' => ReadDouble(),
+            'F' => ReadFloat(),
+            'I' => ReadInt32(),
+            'J' => ReadInt64(),
+            'S' => (short)ReadUInt16(),
+            'Z' => ReadBoolean(),
+            'L' or '[' => ReadContent(),
+            _ => throw new NotSupportedException($"Unsupported field type: {field.TypeCode}")
+        };
+    }
+
+    private object? ReadEnum()
+    {
+        var classDesc = ReadClassDesc();
+        if (classDesc is null)
+        {
+            return null;
+        }
+
+        var constant = ReadContent();
+        RegisterValue(constant);
+        return constant;
+    }
+
+    private object? ReadNewArray()
+    {
+        var classDesc = ReadClassDesc();
+        if (classDesc is null)
+        {
+            return null;
+        }
+
+        var elementType = classDesc.Name[1];
+        var length = ReadInt32();
+        switch (elementType)
+        {
+            case 'B':
+                var handleIndex = RegisterPlaceholder();
+                var bytes = _data.Span.Slice(_position, length).ToArray();
+                _position += length;
+                SetHandle(handleIndex, bytes);
+                return bytes;
+            case 'I':
+                var handleIndex = RegisterPlaceholder();
+                var ints = new int[length];
+                SetHandle(handleIndex, ints);
+                for (var i = 0; i < length; i++)
+                {
+                    ints[i] = ReadInt32();
+                }
+
+                return ints;
+            case 'L':
+            case '[':
+                var list = new List<object?>(length);
+                RegisterHandle(list);
+                for (var i = 0; i < length; i++)
+                {
+                    list.Add(ReadContent());
+                }
+
+                return list;
+            default:
+                throw new NotSupportedException($"Unsupported array component type: {elementType}");
+        }
+    }
+
+    private string ReadNewString()
+    {
+        var value = ReadUtf();
+        RegisterValue(value);
+        return value;
+    }
+
+    private string ReadNewLongString()
+    {
+        var length = ReadInt64();
+        if (length > int.MaxValue)
+        {
+            throw new NotSupportedException("Long strings exceeding Int32 are not supported.");
+        }
+
+        var span = _data.Span.Slice(_position, (int)length);
+        var value = System.Text.Encoding.UTF8.GetString(span);
+        _position += (int)length;
+        RegisterValue(value);
+        return value;
+    }
+
+    private int RegisterPlaceholder()
+    {
+        _handles.Add(null);
+        return _handles.Count - 1;
+    }
+
+    private void SetHandle(int index, object? value)
+    {
+        _handles[index] = value;
+    }
+
+    private void RegisterValue(object? value)
+    {
+        _handles.Add(value);
+    }
+
+    private byte ReadByte()
+    {
+        if (_position >= _data.Length)
+        {
+            throw new InvalidOperationException("Unexpected end of stream.");
+        }
+
+        return _data.Span[_position++];
+    }
+
+    private ushort ReadUInt16()
+    {
+        var value = BinaryPrimitives.ReadUInt16BigEndian(_data.Span.Slice(_position, 2));
+        _position += 2;
+        return value;
+    }
+
+    private short ReadInt16()
+    {
+        var value = BinaryPrimitives.ReadInt16BigEndian(_data.Span.Slice(_position, 2));
+        _position += 2;
+        return value;
+    }
+
+    private int ReadInt32()
+    {
+        var value = BinaryPrimitives.ReadInt32BigEndian(_data.Span.Slice(_position, 4));
+        _position += 4;
+        return value;
+    }
+
+    private long ReadInt64()
+    {
+        var value = BinaryPrimitives.ReadInt64BigEndian(_data.Span.Slice(_position, 8));
+        _position += 8;
+        return value;
+    }
+
+    private float ReadFloat()
+    {
+        var value = BinaryPrimitives.ReadInt32BigEndian(_data.Span.Slice(_position, 4));
+        _position += 4;
+        return BitConverter.Int32BitsToSingle(value);
+    }
+
+    private double ReadDouble()
+    {
+        var value = BinaryPrimitives.ReadInt64BigEndian(_data.Span.Slice(_position, 8));
+        _position += 8;
+        return BitConverter.Int64BitsToDouble(value);
+    }
+
+    private bool ReadBoolean() => ReadByte() != 0;
+
+    private string ReadUtf()
+    {
+        var length = ReadUInt16();
+        if (length == 0)
+        {
+            return string.Empty;
+        }
+
+        var span = _data.Span.Slice(_position, length);
+        var value = System.Text.Encoding.UTF8.GetString(span);
+        _position += length;
+        return value;
+    }
+}
+
+internal static class JavaTokens
+{
+    public const byte Null = 0x70;
+    public const byte Reference = 0x71;
+    public const byte ClassDesc = 0x72;
+    public const byte Object = 0x73;
+    public const byte String = 0x74;
+    public const byte Array = 0x75;
+    public const byte Class = 0x76;
+    public const byte BlockData = 0x77;
+    public const byte EndBlockData = 0x78;
+    public const byte Reset = 0x79;
+    public const byte BlockDataLong = 0x7A;
+    public const byte Exception = 0x7B;
+    public const byte LongString = 0x7C;
+    public const byte ProxyClassDesc = 0x7D;
+    public const byte Enum = 0x7E;
+}
+
+internal sealed record JavaClassDescriptor(
+    string Name,
+    long SerialVersionUid,
+    byte Flags,
+    IReadOnlyList<JavaFieldDescriptor> Fields,
+    JavaClassDescriptor? SuperClass)
+{
+    public bool HasWriteMethod => (Flags & 0x01) != 0;
+}
+
+internal sealed record JavaFieldDescriptor(char TypeCode, string Name, string? ClassName);

--- a/src/CoreProtect.Infrastructure/Decoding/MetadataDecoder.cs
+++ b/src/CoreProtect.Infrastructure/Decoding/MetadataDecoder.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using CoreProtect.Application.Abstractions;
+using CoreProtect.Domain.ValueObjects;
+using SharpNBT;
+
+namespace CoreProtect.Infrastructure.Decoding;
+
+public sealed class MetadataDecoder : IMetadataDecoder
+{
+    private const int MaxParseBytes = 2 * 1024 * 1024;
+    private const int FallbackBytes = 4 * 1024;
+
+    public MetadataDocument Decode(ReadOnlyMemory<byte> data)
+    {
+        if (data.IsEmpty)
+        {
+            return MetadataDocument.Empty;
+        }
+
+        if (data.Length > MaxParseBytes)
+        {
+            return BuildFallback(data);
+        }
+
+        if (TryParseJava(data, out var javaResult))
+        {
+            return new MetadataDocument(javaResult, null, null);
+        }
+
+        if (TryParseNbt(data, out var nbtResult))
+        {
+            return new MetadataDocument(nbtResult, null, null);
+        }
+
+        return BuildFallback(data);
+    }
+
+    private static bool TryParseJava(ReadOnlyMemory<byte> data, out object? result)
+    {
+        var parser = new JavaSerializationParser(data);
+        if (parser.TryParse(out result))
+        {
+            return true;
+        }
+
+        result = null;
+        return false;
+    }
+
+    private static bool TryParseNbt(ReadOnlyMemory<byte> data, out object? result)
+    {
+        try
+        {
+            using var stream = new MemoryStream(data.ToArray(), writable: false);
+            var reader = new TagReader(stream, FormatOptions.Java);
+            var tag = reader.ReadTag();
+            result = ConvertTag(tag);
+            return true;
+        }
+        catch
+        {
+            result = null;
+            return false;
+        }
+    }
+
+    private static object? ConvertTag(Tag tag)
+    {
+        return tag switch
+        {
+            TagCompound compound => compound.ToDictionary(kvp => kvp.Key, kvp => ConvertTag(kvp.Value), StringComparer.Ordinal),
+            TagList list => list.Select(ConvertTag).ToList(),
+            TagByte tagByte => tagByte.Value,
+            TagShort tagShort => tagShort.Value,
+            TagInt tagInt => tagInt.Value,
+            TagLong tagLong => tagLong.Value,
+            TagFloat tagFloat => tagFloat.Value,
+            TagDouble tagDouble => tagDouble.Value,
+            TagString tagString => tagString.Value,
+            TagByteArray byteArray => byteArray.Value.ToArray(),
+            TagIntArray intArray => intArray.Value.ToArray(),
+            TagLongArray longArray => longArray.Value.ToArray(),
+            null => null,
+            _ => tag.ToString()
+        };
+    }
+
+    private static MetadataDocument BuildFallback(ReadOnlyMemory<byte> data)
+    {
+        var sliceLength = Math.Min(data.Length, FallbackBytes);
+        var slice = data.Span.Slice(0, sliceLength);
+        var hex = Convert.ToHexString(slice);
+        var base64 = Convert.ToBase64String(slice);
+        return new MetadataDocument(null, hex, base64);
+    }
+}

--- a/src/CoreProtect.Infrastructure/DependencyInjection.cs
+++ b/src/CoreProtect.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,20 @@
+using CoreProtect.Application.Abstractions;
+using CoreProtect.Infrastructure.Configuration;
+using CoreProtect.Infrastructure.Data;
+using CoreProtect.Infrastructure.Decoding;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CoreProtect.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.Configure<CoreProtectDatabaseOptions>(configuration.GetSection(CoreProtectDatabaseOptions.SectionName));
+        services.AddSingleton<IDbConnectionFactory, MySqlConnectionFactory>();
+        services.AddSingleton<IMetadataDecoder, MetadataDecoder>();
+        services.AddTransient<ICoreProtectReadRepository, CoreProtectReadRepository>();
+        return services;
+    }
+}

--- a/tests/CoreProtect.Tests/CoreProtect.Tests.csproj
+++ b/tests/CoreProtect.Tests/CoreProtect.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/CoreProtect.Application/CoreProtect.Application.csproj" />
+    <ProjectReference Include="../../src/CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj" />
+    <ProjectReference Include="../../src/CoreProtect.Domain/CoreProtect.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/CoreProtect.Tests/MetadataDecoderTests.cs
+++ b/tests/CoreProtect.Tests/MetadataDecoderTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using CoreProtect.Infrastructure.Decoding;
+using SharpNBT;
+using Xunit;
+
+namespace CoreProtect.Tests;
+
+public sealed class MetadataDecoderTests
+{
+    private readonly MetadataDecoder _decoder = new();
+
+    [Fact]
+    public void Decode_WhenEmpty_ReturnsEmpty()
+    {
+        var result = _decoder.Decode(ReadOnlyMemory<byte>.Empty);
+        Assert.Null(result.Json);
+        Assert.Null(result.RawHex);
+        Assert.Null(result.Base64);
+    }
+
+    [Fact]
+    public void Decode_WhenTooLarge_ReturnsFallback()
+    {
+        var data = new byte[5000];
+        var result = _decoder.Decode(data);
+        Assert.Null(result.Json);
+        Assert.NotNull(result.RawHex);
+        Assert.NotNull(result.Base64);
+    }
+
+    [Fact]
+    public void Decode_NbtDocument_ReturnsDictionary()
+    {
+        var compound = new TagCompound
+        {
+            { "name", new TagString("diamond_sword") },
+            { "damage", new TagInt(5) }
+        };
+
+        using var stream = new MemoryStream();
+        var writer = new TagWriter(stream, FormatOptions.Java);
+        writer.WriteTag(compound);
+        var bytes = stream.ToArray();
+
+        var result = _decoder.Decode(bytes);
+        Assert.NotNull(result.Json);
+        var dictionary = Assert.IsType<Dictionary<string, object?>>(result.Json);
+        Assert.Equal("diamond_sword", dictionary["name"]);
+        Assert.Equal(5, dictionary["damage"]);
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold layered .NET 8 solution for a read-only CoreProtect REST API with Docker support
- add MySQL repository implementation, metadata decoding (Java serialization + NBT) and HTTP endpoints with validation, auth, and error handling
- document configuration, runtime expectations, and add unit tests around metadata decoding

## Testing
- not run (dotnet not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d8158923dc8331983ff16247303d9b