### PR TITLE
Fix package restore failures

### DIFF
--- a/src/CoreProtect.Application/CoreProtect.Application.csproj
+++ b/src/CoreProtect.Application/CoreProtect.Application.csproj
@@ -7,5 +7,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../CoreProtect.Domain/CoreProtect.Domain.csproj" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj
+++ b/src/CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="MySqlConnector" Version="2.3.7" />
-    <PackageReference Include="SharpNBT" Version="2.0.1" />
+    <PackageReference Include="SharpNBT" Version="1.3.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- downgrade SharpNBT to the latest available NuGet version so restore succeeds
- add Microsoft.Extensions.DependencyInjection.Abstractions to projects that use IServiceCollection extensions

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d81bf02cf48331b4b49a980eea3c11