### PR TITLE
Add configuration options dependencies to infrastructure project

### DIFF
--- a/src/CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj
+++ b/src/CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj
@@ -14,5 +14,8 @@
     <PackageReference Include="MySqlConnector" Version="2.3.7" />
     <PackageReference Include="SharpNBT" Version="1.3.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add configuration and options extension package references to the infrastructure project to support options binding

## Testing
- ⚠️ `dotnet restore` *(failed: dotnet command not found in environment)*
- ⚠️ `dotnet build` *(not run because dotnet is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68d81f5d5d28833191ce500c315ca206