### PR TITLE
Fix SharpNBT tag mappings after package rename

### DIFF
--- a/src/CoreProtect.Infrastructure/Decoding/MetadataDecoder.cs
+++ b/src/CoreProtect.Infrastructure/Decoding/MetadataDecoder.cs
@@ -71,21 +71,33 @@ public sealed class MetadataDecoder : IMetadataDecoder
     {
         return tag switch
         {
-            TagCompound compound => compound.ToDictionary(kvp => kvp.Key, kvp => ConvertTag(kvp.Value), StringComparer.Ordinal),
-            TagList list => list.Select(ConvertTag).ToList(),
-            TagByte tagByte => tagByte.Value,
-            TagShort tagShort => tagShort.Value,
-            TagInt tagInt => tagInt.Value,
-            TagLong tagLong => tagLong.Value,
-            TagFloat tagFloat => tagFloat.Value,
-            TagDouble tagDouble => tagDouble.Value,
-            TagString tagString => tagString.Value,
-            TagByteArray byteArray => byteArray.Value.ToArray(),
-            TagIntArray intArray => intArray.Value.ToArray(),
-            TagLongArray longArray => longArray.Value.ToArray(),
+            CompoundTag compound => ConvertCompound(compound),
+            ListTag list => list.Select(ConvertTag).ToList(),
+            ByteTag byteTag => byteTag.Value,
+            ShortTag shortTag => shortTag.Value,
+            IntTag intTag => intTag.Value,
+            LongTag longTag => longTag.Value,
+            FloatTag floatTag => floatTag.Value,
+            DoubleTag doubleTag => doubleTag.Value,
+            StringTag stringTag => stringTag.Value,
+            BoolTag boolTag => boolTag.Value,
+            ByteArrayTag byteArray => byteArray.Memory.ToArray(),
+            IntArrayTag intArray => intArray.Memory.ToArray(),
+            LongArrayTag longArray => longArray.Memory.ToArray(),
             null => null,
             _ => tag.ToString()
         };
+    }
+
+    private static IDictionary<string, object?> ConvertCompound(CompoundTag compound)
+    {
+        var dictionary = new Dictionary<string, object?>(compound.Count, StringComparer.Ordinal);
+        foreach (var child in (IEnumerable<KeyValuePair<string, Tag>>)compound)
+        {
+            dictionary[child.Key] = ConvertTag(child.Value);
+        }
+
+        return dictionary;
     }
 
     private static MetadataDocument BuildFallback(ReadOnlyMemory<byte> data)

--- a/tests/CoreProtect.Tests/MetadataDecoderTests.cs
+++ b/tests/CoreProtect.Tests/MetadataDecoderTests.cs
@@ -33,10 +33,10 @@ public sealed class MetadataDecoderTests
     [Fact]
     public void Decode_NbtDocument_ReturnsDictionary()
     {
-        var compound = new TagCompound
+        var compound = new CompoundTag(null)
         {
-            { "name", new TagString("diamond_sword") },
-            { "damage", new TagInt(5) }
+            new StringTag("name", "diamond_sword"),
+            new IntTag("damage", 5)
         };
 
         using var stream = new MemoryStream();


### PR DESCRIPTION
## Summary
- replace usages of legacy SharpNBT Tag* classes with the current tag names
- adjust metadata decoding to materialize compound tags and arrays via the new API
- update the decoder test fixtures to construct CompoundTag instances with the new constructors

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d8243a68b08331b9eb6af76cc8e01a