### PR TITLE
Fix API warnings by updating query requests and dependencies

### DIFF
--- a/src/CoreProtect.Api/CoreProtect.Api.csproj
+++ b/src/CoreProtect.Api/CoreProtect.Api.csproj
@@ -14,5 +14,6 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 </Project>

--- a/src/CoreProtect.Api/Models/BlockQueryRequest.cs
+++ b/src/CoreProtect.Api/Models/BlockQueryRequest.cs
@@ -11,7 +11,7 @@ public sealed class BlockQueryRequest : LogQueryRequest
     public int? BlockTypeId { get; init; }
     public string? Action { get; init; }
 
-    public BlockQueryParameters Build(ApiSettings settings)
+    public new BlockQueryParameters Build(ApiSettings settings)
     {
         var baseParams = base.Build(settings);
         BlockAction? action = null;

--- a/src/CoreProtect.Api/Models/ChatQueryRequest.cs
+++ b/src/CoreProtect.Api/Models/ChatQueryRequest.cs
@@ -8,7 +8,7 @@ public sealed class ChatQueryRequest : LogQueryRequest
 {
     public string? Message { get; init; }
 
-    public ChatQueryParameters Build(ApiSettings settings)
+    public new ChatQueryParameters Build(ApiSettings settings)
     {
         var baseParams = base.Build(settings);
         var messageLike = string.IsNullOrWhiteSpace(Message) ? null : $"%{Message.Trim()}%";

--- a/src/CoreProtect.Api/Models/CommandQueryRequest.cs
+++ b/src/CoreProtect.Api/Models/CommandQueryRequest.cs
@@ -8,7 +8,7 @@ public sealed class CommandQueryRequest : LogQueryRequest
 {
     public string? Command { get; init; }
 
-    public CommandQueryParameters Build(ApiSettings settings)
+    public new CommandQueryParameters Build(ApiSettings settings)
     {
         var baseParams = base.Build(settings);
         var commandLike = string.IsNullOrWhiteSpace(Command) ? null : $"%{Command.Trim()}%";

--- a/src/CoreProtect.Api/Models/ContainerQueryRequest.cs
+++ b/src/CoreProtect.Api/Models/ContainerQueryRequest.cs
@@ -6,7 +6,7 @@ namespace CoreProtect.Api.Models;
 
 public sealed class ContainerQueryRequest : LogQueryRequest
 {
-    public ContainerQueryParameters Build(ApiSettings settings)
+    public new ContainerQueryParameters Build(ApiSettings settings)
     {
         var baseParams = base.Build(settings);
         return new ContainerQueryParameters(baseParams);

--- a/src/CoreProtect.Api/Models/ItemQueryRequest.cs
+++ b/src/CoreProtect.Api/Models/ItemQueryRequest.cs
@@ -6,7 +6,7 @@ namespace CoreProtect.Api.Models;
 
 public sealed class ItemQueryRequest : LogQueryRequest
 {
-    public ItemQueryParameters Build(ApiSettings settings)
+    public new ItemQueryParameters Build(ApiSettings settings)
     {
         var baseParams = base.Build(settings);
         return new ItemQueryParameters(baseParams);

--- a/src/CoreProtect.Api/Models/SessionQueryRequest.cs
+++ b/src/CoreProtect.Api/Models/SessionQueryRequest.cs
@@ -6,7 +6,7 @@ namespace CoreProtect.Api.Models;
 
 public sealed class SessionQueryRequest : LogQueryRequest
 {
-    public SessionQueryParameters Build(ApiSettings settings)
+    public new SessionQueryParameters Build(ApiSettings settings)
     {
         var baseParams = base.Build(settings);
         return new SessionQueryParameters(baseParams);

--- a/src/CoreProtect.Api/Models/SignQueryRequest.cs
+++ b/src/CoreProtect.Api/Models/SignQueryRequest.cs
@@ -6,7 +6,7 @@ namespace CoreProtect.Api.Models;
 
 public sealed class SignQueryRequest : LogQueryRequest
 {
-    public SignQueryParameters Build(ApiSettings settings)
+    public new SignQueryParameters Build(ApiSettings settings)
     {
         var baseParams = base.Build(settings);
         return new SignQueryParameters(baseParams);

--- a/src/CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj
+++ b/src/CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="MySqlConnector" Version="2.3.7" />
     <PackageReference Include="SharpNBT" Version="1.3.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>

--- a/src/CoreProtect.Infrastructure/Decoding/MetadataDecoder.cs
+++ b/src/CoreProtect.Infrastructure/Decoding/MetadataDecoder.cs
@@ -73,6 +73,7 @@ public sealed class MetadataDecoder : IMetadataDecoder
         {
             CompoundTag compound => ConvertCompound(compound),
             ListTag list => list.Select(ConvertTag).ToList(),
+            ByteTag byteTag when byteTag.IsBool => byteTag.Bool,
             ByteTag byteTag => byteTag.Value,
             ShortTag shortTag => shortTag.Value,
             IntTag intTag => intTag.Value,
@@ -80,7 +81,6 @@ public sealed class MetadataDecoder : IMetadataDecoder
             FloatTag floatTag => floatTag.Value,
             DoubleTag doubleTag => doubleTag.Value,
             StringTag stringTag => stringTag.Value,
-            BoolTag boolTag => boolTag.Value,
             ByteArrayTag byteArray => byteArray.Memory.ToArray(),
             IntArrayTag intArray => intArray.Memory.ToArray(),
             LongArrayTag longArray => longArray.Memory.ToArray(),


### PR DESCRIPTION
## Summary
- explicitly mark the specialized Build methods in the API query request DTOs so they intentionally hide the base implementation
- update metadata decoding to consume ByteTag boolean values without using the obsolete BoolTag type
- add the Swashbuckle dependency required for Swagger support and rely on transitive references to avoid duplicate package warnings

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d827902e3c8331a4a9138097e4df5f