### PR TITLE
Handle CoreProtect 23 sign schema

### DIFF
--- a/src/CoreProtect.Api/Models/SignDto.cs
+++ b/src/CoreProtect.Api/Models/SignDto.cs
@@ -23,8 +23,15 @@ public sealed record SignDto(
         entry.Coordinates.X,
         entry.Coordinates.Y,
         entry.Coordinates.Z,
-        entry.Action,
+        ConvertAction(entry.Action),
         entry.Color,
         entry.GlowingText,
         entry.Lines);
+
+    private static string ConvertAction(SignAction action) => action switch
+    {
+        SignAction.Create => "create",
+        SignAction.Remove => "remove",
+        _ => "unknown"
+    };
 }

--- a/src/CoreProtect.Domain/Entities/SignLogEntry.cs
+++ b/src/CoreProtect.Domain/Entities/SignLogEntry.cs
@@ -2,13 +2,40 @@ using CoreProtect.Domain.ValueObjects;
 
 namespace CoreProtect.Domain.Entities;
 
+public enum SignAction
+{
+    Create,
+    Remove,
+    Unknown
+}
+
+public enum SignFace
+{
+    Front,
+    Back
+}
+
+public enum SignGlowState
+{
+    None,
+    Front,
+    Back,
+    Both
+}
+
 public sealed record SignLogEntry(
     long Time,
     DateTimeOffset Timestamp,
     string User,
     string World,
     Coordinates Coordinates,
-    string Action,
+    SignAction Action,
     string? Color,
     string? GlowingText,
-    IReadOnlyList<string> Lines);
+    IReadOnlyList<string> Lines)
+{
+    public string? SecondaryColor { get; init; }
+    public SignGlowState GlowState { get; init; } = SignGlowState.None;
+    public SignFace Face { get; init; } = SignFace.Front;
+    public bool IsWaxed { get; init; }
+}


### PR DESCRIPTION
## Summary
- update the sign query to match the new CoreProtect columns (color_secondary, data, waxed, face)
- map sign actions, glow states, colors, face, and waxed flag without breaking the existing DTO
- expose sign action strings via a dedicated mapper and carry the extra metadata in the domain model

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d82a9e94488331b815dcba8111eb5a