### PR TITLE
Add health check dependencies and fix request builder warning

### DIFF
--- a/src/CoreProtect.Api/CoreProtect.Api.csproj
+++ b/src/CoreProtect.Api/CoreProtect.Api.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.5" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />

--- a/src/CoreProtect.Api/Models/TimeRangeQueryRequest.cs
+++ b/src/CoreProtect.Api/Models/TimeRangeQueryRequest.cs
@@ -18,7 +18,7 @@ public sealed class TimeRangeQueryRequest : SimplePaginationRequest
         }
     }
 
-    public TimeRangeQueryParameters Build(ApiSettings settings)
+    public new TimeRangeQueryParameters Build(ApiSettings settings)
     {
         var pagination = base.BuildPagination(settings);
         return new TimeRangeQueryParameters(From, To, pagination);

--- a/src/CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj
+++ b/src/CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.5" />
     <PackageReference Include="MySqlConnector" Version="2.3.7" />
     <PackageReference Include="SharpNBT" Version="1.3.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />

--- a/tests/CoreProtect.Tests/CoreProtect.Tests.csproj
+++ b/tests/CoreProtect.Tests/CoreProtect.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.5" />
     <PackageReference Include="xunit" Version="2.6.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />


### PR DESCRIPTION
## Summary
- add the Microsoft.Extensions.Diagnostics.HealthChecks package to the API, infrastructure, and test projects so health check abstractions resolve correctly
- mark TimeRangeQueryRequest.Build as intentionally hiding the pagination method while reusing the base pagination builder

## Testing
- not run (dotnet CLI unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d9023dd0888331aa858cbd5a935b8d