### PR TITLE
Resolve Microsoft.Extensions.Options downgrade warnings

### DIFF
--- a/src/CoreProtect.Api/CoreProtect.Api.csproj
+++ b/src/CoreProtect.Api/CoreProtect.Api.csproj
@@ -13,8 +13,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 </Project>

--- a/src/CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj
+++ b/src/CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="MySqlConnector" Version="2.3.7" />
     <PackageReference Include="SharpNBT" Version="1.3.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- align Microsoft.Extensions.Options package versions in the API and infrastructure projects with the HealthChecks dependency requirements to prevent restore-time downgrades

## Testing
- dotnet build *(fails: .NET SDK is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d90464fb4483318dc673af203ffef9