### PR TITLE
Fix health check dependency registration and resolve package downgrade

### DIFF
--- a/src/CoreProtect.Api/CoreProtect.Api.csproj
+++ b/src/CoreProtect.Api/CoreProtect.Api.csproj
@@ -13,7 +13,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.5" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>

--- a/src/CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj
+++ b/src/CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="MySqlConnector" Version="2.3.7" />
     <PackageReference Include="SharpNBT" Version="1.3.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.5" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.5" />
   </ItemGroup>
 </Project>

--- a/src/CoreProtect.Infrastructure/DependencyInjection.cs
+++ b/src/CoreProtect.Infrastructure/DependencyInjection.cs
@@ -2,6 +2,7 @@ using CoreProtect.Application.Abstractions;
 using CoreProtect.Infrastructure.Configuration;
 using CoreProtect.Infrastructure.Data;
 using CoreProtect.Infrastructure.Decoding;
+using CoreProtect.Infrastructure.HealthChecks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -15,6 +16,7 @@ public static class DependencyInjection
         services.AddSingleton<IDbConnectionFactory, MySqlConnectionFactory>();
         services.AddSingleton<IMetadataDecoder, MetadataDecoder>();
         services.AddSingleton<ICoreProtectSchemaVerifier, CoreProtectSchemaVerifier>();
+        services.AddSingleton<CoreProtectSchemaHealthCheck>();
         services.AddTransient<ICoreProtectReadRepository, CoreProtectReadRepository>();
         return services;
     }


### PR DESCRIPTION
## Summary
- register `CoreProtectSchemaHealthCheck` with the infrastructure service collection
- remove redundant direct Microsoft.Extensions.Options package references to avoid version downgrade warnings

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d90c5c20088331ba2b11cad83da06d