### PR TITLE
Add extension for registering CoreProtect schema health check

### DIFF
--- a/src/CoreProtect.Api/Program.cs
+++ b/src/CoreProtect.Api/Program.cs
@@ -2,7 +2,6 @@ using CoreProtect.Api.Configuration;
 using CoreProtect.Api.Middleware;
 using CoreProtect.Application;
 using CoreProtect.Infrastructure;
-using CoreProtect.Infrastructure.HealthChecks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpLogging;
 using Microsoft.AspNetCore.Mvc;
@@ -42,7 +41,7 @@ builder.Services.AddHttpLogging(logging =>
 builder.Services.AddCors();
 builder.Services.AddHealthChecks()
     .AddCheck("self", () => HealthCheckResult.Healthy(), tags: new[] { "live" })
-    .AddCheck<CoreProtectSchemaHealthCheck>("coreprotect_schema", tags: new[] { "ready" });
+    .AddCoreProtectSchemaCheck();
 
 var app = builder.Build();
 

--- a/src/CoreProtect.Infrastructure/HealthChecks/HealthCheckBuilderExtensions.cs
+++ b/src/CoreProtect.Infrastructure/HealthChecks/HealthCheckBuilderExtensions.cs
@@ -1,0 +1,18 @@
+using System;
+using CoreProtect.Infrastructure.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace CoreProtect.Infrastructure;
+
+public static class HealthCheckBuilderExtensions
+{
+    private const string CoreProtectSchemaCheckName = "coreprotect_schema";
+    private static readonly string[] ReadyTags = new[] { "ready" };
+
+    public static IHealthChecksBuilder AddCoreProtectSchemaCheck(this IHealthChecksBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.AddCheck<CoreProtectSchemaHealthCheck>(CoreProtectSchemaCheckName, tags: ReadyTags);
+    }
+}


### PR DESCRIPTION
## Summary
- add an infrastructure extension method to register the CoreProtect schema health check
- update the API composition root to use the extension instead of referencing the infrastructure health check namespace directly

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d90dbb7b6883319c576e50e68dc037