### PR TITLE
Fix health check registration and adjust nullable handling

### DIFF
--- a/src/CoreProtect.Api/CoreProtect.Api.csproj
+++ b/src/CoreProtect.Api/CoreProtect.Api.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 </Project>

--- a/src/CoreProtect.Api/Models/DatabaseLockDto.cs
+++ b/src/CoreProtect.Api/Models/DatabaseLockDto.cs
@@ -7,7 +7,7 @@ public sealed record DatabaseLockDto(int RowId, int? Status, long? Time, string?
     public static DatabaseLockDto FromDomain(DatabaseLockInfo info)
     {
         var timestamp = info.Timestamp?.ToUniversalTime().ToString("O");
-        var isLocked = info.Status is null ? null : info.Status != 0;
+        var isLocked = info.Status is null ? (bool?)null : info.Status != 0;
         return new DatabaseLockDto(info.RowId, info.Status, info.Time, timestamp, isLocked);
     }
 }

--- a/src/CoreProtect.Api/Program.cs
+++ b/src/CoreProtect.Api/Program.cs
@@ -2,6 +2,7 @@ using CoreProtect.Api.Configuration;
 using CoreProtect.Api.Middleware;
 using CoreProtect.Application;
 using CoreProtect.Infrastructure;
+using CoreProtect.Infrastructure.HealthChecks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpLogging;
 using Microsoft.AspNetCore.Mvc;

--- a/src/CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj
+++ b/src/CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj
@@ -11,10 +11,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.35" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.6" />
     <PackageReference Include="MySqlConnector" Version="2.3.7" />
     <PackageReference Include="SharpNBT" Version="1.3.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.6" />
   </ItemGroup>
 </Project>

--- a/src/CoreProtect.Infrastructure/HealthChecks/HealthCheckBuilderExtensions.cs
+++ b/src/CoreProtect.Infrastructure/HealthChecks/HealthCheckBuilderExtensions.cs
@@ -2,7 +2,7 @@ using System;
 using CoreProtect.Infrastructure.HealthChecks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
-namespace CoreProtect.Infrastructure;
+namespace CoreProtect.Infrastructure.HealthChecks;
 
 public static class HealthCheckBuilderExtensions
 {


### PR DESCRIPTION
## Summary
- expose the CoreProtect health check builder extension via the infrastructure namespace used by the API
- correct nullable handling when mapping database lock status
- align Microsoft.Extensions package versions to 8.0.6 to avoid restore downgrades

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d90f465514833182f6b06da5292b4c