### PR TITLE
Fix missing Microsoft.Extensions dependencies in infrastructure project

### DIFF
--- a/src/CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj
+++ b/src/CoreProtect.Infrastructure/CoreProtect.Infrastructure.csproj
@@ -11,6 +11,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="MySqlConnector" Version="2.3.7" />
     <PackageReference Include="SharpNBT" Version="1.3.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />


### PR DESCRIPTION
## Summary
- add the Microsoft.Extensions configuration and options packages to the infrastructure project so AddInfrastructure compiles and runs

## Testing
- dotnet build
- dotnet test *(fails: MetadataDecoderTests currently red in main)*

------
https://chatgpt.com/codex/tasks/task_e_68d91f2e81b083319125e88aa2095ce7