### PR TITLE
Ensure CoreProtectReadRepository implements GetArtMapAsync

### DIFF
--- a/src/CoreProtect.Infrastructure/Data/CoreProtectReadRepository.cs
+++ b/src/CoreProtect.Infrastructure/Data/CoreProtectReadRepository.cs
@@ -147,6 +147,11 @@ SELECT DISTINCT id, current_user, uuid FROM name_history ORDER BY time DESC";
         return QueryAsync(sql, parameters, MapArtMap, cancellationToken);
     }
 
+    Task<IReadOnlyList<ArtMapEntry>> ICoreProtectReadRepository.GetArtMapAsync(
+        Pagination pagination,
+        CancellationToken cancellationToken) =>
+        GetArtMapAsync(pagination, cancellationToken);
+
     public Task<IReadOnlyList<BlockDataMapEntry>> GetBlockDataMapAsync(Pagination pagination, CancellationToken cancellationToken)
     {
         const string sql = "SELECT rowid, id, data FROM co_blockdata_map ORDER BY id LIMIT @limit OFFSET @offset";

--- a/tests/CoreProtect.Tests/CoreProtectReadRepositoryTypeTests.cs
+++ b/tests/CoreProtect.Tests/CoreProtectReadRepositoryTypeTests.cs
@@ -12,4 +12,11 @@ public sealed class CoreProtectReadRepositoryTypeTests
         var type = typeof(CoreProtectReadRepository);
         Assert.True(typeof(ICoreProtectReadRepository).IsAssignableFrom(type));
     }
+
+    [Fact]
+    public void CoreProtectReadRepository_ShouldExposeArtMapQuery()
+    {
+        var interfaceMap = typeof(CoreProtectReadRepository).GetInterfaceMap(typeof(ICoreProtectReadRepository));
+        Assert.Contains(interfaceMap.InterfaceMethods, method => method.Name == nameof(ICoreProtectReadRepository.GetArtMapAsync));
+    }
 }


### PR DESCRIPTION
## Summary
- add an explicit interface implementation for GetArtMapAsync to the CoreProtect read repository to resolve the missing method at runtime
- extend the repository type tests to verify the ArtMap query implementation is available via the interface

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d9258a16e08331a4b4f287110078d0