### PR TITLE
Fix TypeLoadException by consolidating ArtMap query implementation

### DIFF
--- a/src/CoreProtect.Infrastructure/Data/CoreProtectReadRepository.cs
+++ b/src/CoreProtect.Infrastructure/Data/CoreProtectReadRepository.cs
@@ -142,15 +142,24 @@ SELECT DISTINCT id, current_user, uuid FROM name_history ORDER BY time DESC";
 
     public Task<IReadOnlyList<ArtMapEntry>> GetArtMapAsync(Pagination pagination, CancellationToken cancellationToken)
     {
-        const string sql = "SELECT rowid, id, art FROM co_art_map ORDER BY id LIMIT @limit OFFSET @offset";
-        var parameters = CreatePaginationParameters(pagination);
-        return QueryAsync(sql, parameters, MapArtMap, cancellationToken);
+        return GetArtMapEntriesAsync(pagination, cancellationToken);
     }
 
     Task<IReadOnlyList<ArtMapEntry>> ICoreProtectReadRepository.GetArtMapAsync(
         Pagination pagination,
-        CancellationToken cancellationToken) =>
-        GetArtMapAsync(pagination, cancellationToken);
+        CancellationToken cancellationToken)
+    {
+        return GetArtMapEntriesAsync(pagination, cancellationToken);
+    }
+
+    private Task<IReadOnlyList<ArtMapEntry>> GetArtMapEntriesAsync(
+        Pagination pagination,
+        CancellationToken cancellationToken)
+    {
+        const string sql = "SELECT rowid, id, art FROM co_art_map ORDER BY id LIMIT @limit OFFSET @offset";
+        var parameters = CreatePaginationParameters(pagination);
+        return QueryAsync(sql, parameters, MapArtMap, cancellationToken);
+    }
 
     public Task<IReadOnlyList<BlockDataMapEntry>> GetBlockDataMapAsync(Pagination pagination, CancellationToken cancellationToken)
     {

--- a/tests/CoreProtect.Tests/CoreProtectReadRepositoryTypeTests.cs
+++ b/tests/CoreProtect.Tests/CoreProtectReadRepositoryTypeTests.cs
@@ -18,5 +18,6 @@ public sealed class CoreProtectReadRepositoryTypeTests
     {
         var interfaceMap = typeof(CoreProtectReadRepository).GetInterfaceMap(typeof(ICoreProtectReadRepository));
         Assert.Contains(interfaceMap.InterfaceMethods, method => method.Name == nameof(ICoreProtectReadRepository.GetArtMapAsync));
+        Assert.Contains(interfaceMap.TargetMethods, method => method.Name == nameof(CoreProtectReadRepository.GetArtMapAsync));
     }
 }

--- a/tests/CoreProtect.Tests/DependencyInjectionTests.cs
+++ b/tests/CoreProtect.Tests/DependencyInjectionTests.cs
@@ -1,0 +1,20 @@
+using CoreProtect.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace CoreProtect.Tests;
+
+public sealed class DependencyInjectionTests
+{
+    [Fact]
+    public void AddInfrastructure_ShouldRegisterServicesWithoutTypeLoadExceptions()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+
+        var exception = Record.Exception(() => services.AddInfrastructure(configuration));
+
+        Assert.Null(exception);
+    }
+}


### PR DESCRIPTION
## Summary
- route both the public and interface implementations of `GetArtMapAsync` through a shared helper to guarantee the method body is emitted
- extend the repository type tests to assert the interface map is backed by the concrete `GetArtMapAsync` method
- add a dependency injection smoke test to detect `AddInfrastructure` regressions that would reintroduce the type load failure

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d926d74b1c83319f65e04842538dec