### PR TITLE
Add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore CoreProtectAPI.sln
+
+      - name: Build solution
+        run: dotnet build CoreProtectAPI.sln --configuration Release --no-restore
+
+      - name: Run tests
+        run: dotnet test CoreProtectAPI.sln --configuration Release --no-build --logger "trx;LogFileName=test-results.trx"
+
+      - name: Upload test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: '**/TestResults/*.trx'
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ dotnet watch --project src/CoreProtect.Api/CoreProtect.Api.csproj run
 
 Recommended IDE extensions: C# Dev Kit / Rider, SQL syntax highlighting, EditorConfig support.
 
+## Continuous integration
+
+Automated builds run on GitHub Actions (`.github/workflows/dotnet.yml`) for every push and pull request targeting `main`. The pipeline restores dependencies, builds the solution in Release mode, executes the full test suite, and publishes `.trx` results as workflow artifacts for post-run inspection.
+
 ## Docker
 
 ```bash


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to restore, build, and test the solution on pushes and pull requests
- document the new CI pipeline in the README for quick visibility

## Testing
- dotnet test *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d929639b0c8331a112cc4d8272317e